### PR TITLE
Updated Realisations

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,75 @@
+name: Pytest Check
+
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install GMT
+        run: sudo apt-get install -y gmt libgmt-dev ghostscript
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Run tests
+        run: |
+          pytest --cov=workflow --cov-report=html tests
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data
+          path: .coverage
+          include-hidden-files: true
+          if-no-files-found: ignore
+
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade coverage[toml]
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-data
+
+      - name: Combine coverage and fail it it’s under 100 %
+        run: |
+          python -m coverage html --skip-covered --skip-empty
+
+          # Report and write to summary.
+          python -m coverage report | sed 's/^/    /' >> $GITHUB_STEP_SUMMARY
+
+          # Report again and fail if under 95%.
+          python -Im coverage report --fail-under=95
+
+      - name: Upload HTML report if check failed
+        uses: actions/upload-artifact@v4
+
+        with:
+          name: html-report
+          path: htmlcov
+
+        if: ${{ failure() }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,65 @@ requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "PACKAGE NAME HERE"
+name = "workflow"
 authors = [
     {name = "QuakeCoRE" },
 ]
-description = "PACKAGE DESCRIPTION HERE"
+description = "Next generation workflow powered by cylc."
 readme = "README.md"
 requires-python = ">=3.12"
 dynamic = ["version", "dependencies"]
 
+[tool.setuptools.package-dir]
+workflow = "workflow"
+
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 
-[tool.setuptools.package-dir]
-workflow = "workflow"
+[tool.ruff.lint]
+extend-select = [
+  # isort imports
+  "I",
+  # Use r'\s+' rather than '\s+'
+  "W605",
+  # All the naming errors, like using camel case for function names.
+  "N",
+  # Missing docstrings in classes, methods, and functions
+  "D101",
+  "D102",
+  "D103",
+  "D105",
+  "D107",
+  # Use f-string instead of a format call
+  "UP032",
+  # Standard library import is deprecated
+  "UP035",
+  # Missing function argument type-annotation
+  "ANN001",
+  # Using except without specifying an exception type to catch
+  "BLE001"
+]
+ignore = ["D104"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.isort]
+known-first-party = [
+    "source_modelling",
+    "workflow",
+    "pygmt_helper",
+    "qcore",
+    "empirical",
+    "nshmdb",
+    "IM_calculation",
+    "mera"
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore no docstring in __init__.py
+"__init__.py" = ["D104"]
+# Ignore docstring errors in tests folder
+"tests/**.py" = ["D"]
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ dynamic = ["version", "dependencies"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools.package-dir]
+workflow = "workflow"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
 pyyaml
+source_modelling @ git+https://github.com/ucgmsim/source_modelling
+velocity_modelling @ git+https://github.com/ucgmsim/velocity_modelling
+numpy
+pytest
+schema

--- a/tests/test_realisation.py
+++ b/tests/test_realisation.py
@@ -1,0 +1,403 @@
+# NOTE: this fix contains tests that mirror the Realisations wiki. If
+# these tests fail, you should update the wiki if necesary to ensure
+# it stays consistent with the codebase.
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import schema
+from velocity_modelling import bounding_box
+
+from source_modelling import rupture_propagation
+from workflow import defaults, realisations
+
+
+def test_bounding_box_example(tmp_path: Path):
+    domain_parameters = realisations.DomainParameters(
+        resolution=0.1,  # a 0.1km resolution
+        domain=bounding_box.BoundingBox.from_centroid_bearing_extents(
+            centroid=np.array([-43.53092, 172.63701]),
+            bearing=45.0,
+            extent_x=100.0,
+            extent_y=100.0,
+        ),
+        depth=40.0,
+        duration=60.0,
+        dt=0.005,
+    )
+    realisation_ffp = tmp_path / "realisation.json"
+    domain_parameters.write_to_realisation(realisation_ffp)
+    with open(realisation_ffp, "r") as realisation_handle:
+        assert json.load(realisation_handle) == {
+            "domain": {
+                "resolution": 0.1,
+                "domain": [
+                    {"latitude": -43.524793866326725, "longitude": 171.76204128885567},
+                    {"latitude": -44.16756820707226, "longitude": 172.63312824122775},
+                    {"latitude": -43.53034935969409, "longitude": 173.51210368762364},
+                    {"latitude": -42.894200350955856, "longitude": 172.64076673694242},
+                ],
+                "depth": 40.0,
+                "duration": 60.0,
+                "dt": 0.005,
+            }
+        }
+    domain_parameters_read = realisations.DomainParameters.read_from_realisation(
+        realisation_ffp
+    )
+    assert domain_parameters_read.depth == domain_parameters.depth
+    assert domain_parameters_read.duration == domain_parameters.duration
+    assert domain_parameters_read.dt == domain_parameters.dt
+    assert domain_parameters_read.resolution == domain_parameters.resolution
+    assert (
+        domain_parameters_read.domain.corners == domain_parameters.domain.corners
+    ).all()
+
+
+def test_domain_parameters_properties():
+    domain_parameters = realisations.DomainParameters(
+        resolution=0.1,  # a 0.1km resolution
+        domain=bounding_box.BoundingBox.from_centroid_bearing_extents(
+            centroid=np.array([-43.53092, 172.63701]),
+            bearing=45.0,
+            extent_x=100.0,
+            extent_y=100.0,
+        ),
+        depth=40.0,
+        duration=60.0,
+        dt=0.005,
+    )
+    assert domain_parameters.nx == 1000
+    assert domain_parameters.ny == 1000
+    assert domain_parameters.nz == 400
+
+
+def test_srf_config_example(tmp_path):
+    domain_parameters = realisations.DomainParameters(
+        resolution=0.1,  # a 0.1km resolution
+        domain=bounding_box.BoundingBox.from_centroid_bearing_extents(
+            centroid=np.array([-43.53092, 172.63701]),
+            bearing=45.0,
+            extent_x=100.0,
+            extent_y=100.0,
+        ),
+        depth=40.0,
+        duration=60.0,
+        dt=0.005,
+    )
+    srf_config = realisations.SRFConfig(
+        genslip_dt=1.0,
+        genslip_seed=1,
+        genslip_version="5.4.2",
+        resolution=0.1,
+        srfgen_seed=1,
+    )
+
+    realisation_ffp = tmp_path / "realisation.json"
+    domain_parameters.write_to_realisation(realisation_ffp)
+    srf_config.write_to_realisation(realisation_ffp)
+    with open(realisation_ffp, "r") as realisation_handle:
+        assert json.load(realisation_handle) == {
+            "domain": {
+                "resolution": 0.1,
+                "domain": [
+                    {"latitude": -43.524793866326725, "longitude": 171.76204128885567},
+                    {"latitude": -44.16756820707226, "longitude": 172.63312824122775},
+                    {"latitude": -43.53034935969409, "longitude": 173.51210368762364},
+                    {"latitude": -42.894200350955856, "longitude": 172.64076673694242},
+                ],
+                "depth": 40.0,
+                "duration": 60.0,
+                "dt": 0.005,
+            },
+            "srf": {
+                "genslip_dt": 1.0,
+                "genslip_seed": 1,
+                "resolution": 0.1,
+                "genslip_version": "5.4.2",
+                "srfgen_seed": 1,
+            },
+        }
+
+    assert realisations.SRFConfig.read_from_realisation(realisation_ffp) == srf_config
+
+
+def test_bad_domain_parameters(tmp_path: Path):
+    bad_json = tmp_path / "bad_domain_parameters.json"
+    bad_json.write_text(
+        json.dumps(
+            {
+                "domain": {
+                    "resolution": 0,  # Set to 0
+                    "domain": [
+                        {
+                            "latitude": -43.524793866326725,
+                            "longitude": 171.76204128885567,
+                        },
+                        {
+                            "latitude": -42.894200350955856,
+                            "longitude": 172.64076673694242,
+                        },
+                        {
+                            "latitude": -43.53034935969409,
+                            "longitude": 173.51210368762364,
+                        },
+                        {
+                            "latitude": -44.16756820707226,
+                            "longitude": 172.63312824122775,
+                        },
+                    ],
+                    "depth": 40.0,
+                    "duration": 60.0,
+                    "dt": 0.005,
+                }
+            }
+        )
+    )
+    with pytest.raises(schema.SchemaError):
+        realisations.DomainParameters.read_from_realisation(bad_json)
+
+
+def test_bad_config_key(tmp_path: Path):
+    bad_json = tmp_path / "bad_domain_parameters.json"
+    bad_json.write_text(
+        json.dumps(
+            {
+                "not the correct domain key": {
+                    "resolution": 0.1,
+                    "domain": [
+                        {
+                            "latitude": -43.524793866326725,
+                            "longitude": 171.76204128885567,
+                        },
+                        {
+                            "latitude": -42.894200350955856,
+                            "longitude": 172.64076673694242,
+                        },
+                        {
+                            "latitude": -43.53034935969409,
+                            "longitude": 173.51210368762364,
+                        },
+                        {
+                            "latitude": -44.16756820707226,
+                            "longitude": 172.63312824122775,
+                        },
+                    ],
+                    "depth": 40.0,
+                    "duration": 60.0,
+                    "dt": 0.005,
+                }
+            }
+        )
+    )
+    with pytest.raises(realisations.RealisationParseError):
+        realisations.DomainParameters.read_from_realisation(bad_json)
+
+
+def test_metadata(tmp_path: Path):
+    metadata = realisations.RealisationMetadata(
+        name="consecutive write test",
+        version="1",
+        defaults_version=defaults.DefaultsVersion.develop,
+    )
+    realisation_ffp = tmp_path / "realisation.json"
+    metadata.write_to_realisation(realisation_ffp)
+    with open(realisation_ffp, "r") as realisation_handle:
+        assert json.load(realisation_handle) == {
+            "metadata": {
+                "name": "consecutive write test",
+                "version": "1",
+                "defaults_version": "develop",
+                "tag": None,
+            },
+        }
+
+    assert (
+        realisations.RealisationMetadata.read_from_realisation(realisation_ffp)
+        == metadata
+    )
+
+
+def test_velocity_model(tmp_path: Path):
+    velocity_model = realisations.VelocityModelParameters(
+        min_vs=1.0,
+        version="2.06",
+        topo_type="SQUASHED_TAPERED",
+        dt=0.05,
+        ds_multiplier=1.2,
+        resolution=0.1,
+        vs30=300.0,
+        s_wave_velocity=3500.0,
+        pgv_interpolants=np.ones(shape=(2, 2), dtype=np.float32),
+    )
+    realisation_ffp = tmp_path / "realisation.json"
+    velocity_model.write_to_realisation(realisation_ffp)
+    with open(realisation_ffp, "r") as realisation_handle:
+        assert json.load(realisation_handle) == {
+            "velocity_model": {
+                "min_vs": 1.0,
+                "version": "2.06",
+                "topo_type": "SQUASHED_TAPERED",
+                "dt": 0.05,
+                "ds_multiplier": 1.2,
+                "resolution": 0.1,
+                "vs30": 300.0,
+                "s_wave_velocity": 3500.0,
+                "pgv_interpolants": [[1, 1], [1, 1]],
+            }
+        }
+
+    assert (
+        realisations.VelocityModelParameters.read_from_realisation(
+            realisation_ffp
+        ).to_dict()
+        == velocity_model.to_dict()
+    )
+
+
+def test_rupture_prop_config(tmp_path: Path):
+    rup_prop = realisations.RupturePropagationConfig(
+        rupture_causality_tree={"A": None, "B": "A", "C": "B"},
+        jump_points={
+            "B": rupture_propagation.JumpPair(
+                from_point=np.array([0.0, 1.0]), to_point=np.array([0.0, 0.0])
+            ),
+            "C": rupture_propagation.JumpPair(
+                from_point=np.array([0.25, 0.8]), to_point=np.array([0.5, 0.333])
+            ),
+        },
+        rakes={"A": 100.0, "B": 67.0, "C": 125.0},
+        magnitudes={"A": 6.5, "B": 6.7, "C": 6.9},
+        hypocentre=np.array([0.0, 0.6]),
+    )
+
+    realisation_ffp = tmp_path / "realisation.json"
+    rup_prop.write_to_realisation(realisation_ffp)
+    with open(realisation_ffp, "r") as realisation_handle:
+        assert json.load(realisation_handle) == {
+            "rupture_propagation": {
+                "rupture_causality_tree": {"A": None, "B": "A", "C": "B"},
+                "jump_points": {
+                    "B": {
+                        "from_point": {"s": 0.0, "d": 1.0},
+                        "to_point": {"s": 0.0, "d": 0.0},
+                    },
+                    "C": {
+                        "from_point": {"s": 0.25, "d": 0.8},
+                        "to_point": {"s": 0.5, "d": 0.333},
+                    },
+                },
+                "rakes": {"A": 100.0, "B": 67.0, "C": 125.0},
+                "magnitudes": {"A": 6.5, "B": 6.7, "C": 6.9},
+                "hypocentre": {"s": 0.0, "d": 0.6},
+            }
+        }
+    rupture_prop_config = realisations.RupturePropagationConfig.read_from_realisation(
+        realisation_ffp
+    )
+    assert rupture_prop_config.rupture_causality_tree == {"A": None, "B": "A", "C": "B"}
+    assert rupture_prop_config.jump_points["B"].from_point.tolist() == [0.0, 1.0]
+    assert rupture_prop_config.jump_points["B"].to_point.tolist() == [0.0, 0.0]
+    assert rupture_prop_config.jump_points["C"].from_point.tolist() == [0.25, 0.8]
+    assert rupture_prop_config.jump_points["C"].to_point.tolist() == [0.5, 0.333]
+    assert rupture_prop_config.rakes == {"A": 100.0, "B": 67.0, "C": 125.0}
+    assert rupture_prop_config.magnitudes == {"A": 6.5, "B": 6.7, "C": 6.9}
+    assert rupture_prop_config.hypocentre.tolist() == [0.0, 0.6]
+
+
+def test_rupture_prop_properties():
+    rup_prop = realisations.RupturePropagationConfig(
+        rupture_causality_tree={"A": None, "B": "A", "C": "B"},
+        jump_points={
+            "B": rupture_propagation.JumpPair(
+                from_point=np.array([0.0, 1.0]), to_point=np.array([0.0, 0.0])
+            ),
+            "C": rupture_propagation.JumpPair(
+                from_point=np.array([0.25, 0.8]), to_point=np.array([0.5, 0.333])
+            ),
+        },
+        rakes={"A": 100.0, "B": 67.0, "C": 125.0},
+        magnitudes={"A": 6.5, "B": 6.7, "C": 6.9},
+        hypocentre=np.array([0.0, 0.6]),
+    )
+    assert rup_prop.initial_fault == "A"
+
+
+def test_hf_config(tmp_path):
+    test_realisation = tmp_path / "realisation.json"
+    test_realisation.write_text("{}")
+    hf_config = realisations.HFConfig.read_from_realisation_or_defaults(
+        test_realisation, defaults.DefaultsVersion.v24_2_2_1
+    )
+    hf_config.write_to_realisation(test_realisation)
+    assert realisations.HFConfig.read_from_realisation(test_realisation) == hf_config
+    # Test that realisation parameters override defaults.
+    hf_config.dt = 0.1
+    hf_config.write_to_realisation(test_realisation)
+    assert (
+        realisations.HFConfig.read_from_realisation_or_defaults(
+            test_realisation, defaults.DefaultsVersion.v24_2_2_1
+        )
+        == hf_config
+    )
+
+
+def test_emod3d(tmp_path: Path):
+    test_realisation = tmp_path / "realisation.json"
+    test_realisation.write_text("{}")
+    emod3d = realisations.EMOD3DParameters.read_from_realisation_or_defaults(
+        test_realisation, defaults.DefaultsVersion.v24_2_2_1
+    )
+    emod3d.write_to_realisation(test_realisation)
+    assert (
+        realisations.EMOD3DParameters.read_from_realisation(test_realisation) == emod3d
+    )
+    emod3d.write_to_realisation(test_realisation)
+    assert (
+        realisations.EMOD3DParameters.read_from_realisation_or_defaults(
+            test_realisation, defaults.DefaultsVersion.v24_2_2_1
+        )
+        == emod3d
+    )
+
+
+def test_broadband_parameters(tmp_path: Path):
+    test_realisation = tmp_path / "realisation.json"
+    broadband_parameters = realisations.BroadbandParameters(
+        flo=0.5, dt=0.005, fmidbot=0.5, fmin=0.25, site_amp_version="2014"
+    )
+    broadband_parameters.write_to_realisation(test_realisation)
+    with open(test_realisation, "r") as realisation_handle:
+        assert json.load(realisation_handle) == {
+            "bb": {
+                "flo": 0.5,
+                "dt": 0.005,
+                "fmidbot": 0.5,
+                "fmin": 0.25,
+                "site_amp_version": "2014",
+            }
+        }
+    assert (
+        realisations.BroadbandParameters.read_from_realisation(test_realisation)
+        == broadband_parameters
+    )
+
+
+@pytest.mark.parametrize(
+    "realisation_config",
+    [
+        realisations.EMOD3DParameters,
+        realisations.HFConfig,
+        realisations.SRFConfig,
+        realisations.VelocityModelParameters,
+        realisations.BroadbandParameters,
+    ],
+)
+@pytest.mark.parametrize("defaults_version", list(defaults.DefaultsVersion))
+def test_defaults_are_loadable(
+    tmp_path: Path,
+    realisation_config: realisations.RealisationConfiguration,
+    defaults_version: defaults.DefaultsVersion,
+):
+    realisation_config.read_from_defaults(defaults_version)

--- a/tests/test_realisation.py
+++ b/tests/test_realisation.py
@@ -68,7 +68,7 @@ def test_domain_parameters_properties():
     assert domain_parameters.nz == 400
 
 
-def test_srf_config_example(tmp_path):
+def test_srf_config_example(tmp_path: Path):
     domain_parameters = realisations.DomainParameters(
         resolution=0.1,  # a 0.1km resolution
         domain=bounding_box.BoundingBox.from_centroid_bearing_extents(
@@ -308,7 +308,7 @@ def test_rupture_prop_properties():
     assert rup_prop.initial_fault == "A"
 
 
-def test_hf_config(tmp_path):
+def test_hf_config(tmp_path: Path):
     test_realisation = tmp_path / "realisation.json"
     test_realisation.write_text("{}")
     hf_config = realisations.HFConfig.read_from_realisation_or_defaults(

--- a/tests/test_realisation.py
+++ b/tests/test_realisation.py
@@ -32,12 +32,7 @@ def test_bounding_box_example(tmp_path: Path):
         assert json.load(realisation_handle) == {
             "domain": {
                 "resolution": 0.1,
-                "domain": [
-                    {"latitude": -43.524793866326725, "longitude": 171.76204128885567},
-                    {"latitude": -44.16756820707226, "longitude": 172.63312824122775},
-                    {"latitude": -43.53034935969409, "longitude": 173.51210368762364},
-                    {"latitude": -42.894200350955856, "longitude": 172.64076673694242},
-                ],
+                "domain": realisations.to_name_coordinate_dictionary(domain_parameters.domain.corners),
                 "depth": 40.0,
                 "duration": 60.0,
                 "dt": 0.005,
@@ -99,18 +94,7 @@ def test_srf_config_example(tmp_path):
     srf_config.write_to_realisation(realisation_ffp)
     with open(realisation_ffp, "r") as realisation_handle:
         assert json.load(realisation_handle) == {
-            "domain": {
-                "resolution": 0.1,
-                "domain": [
-                    {"latitude": -43.524793866326725, "longitude": 171.76204128885567},
-                    {"latitude": -44.16756820707226, "longitude": 172.63312824122775},
-                    {"latitude": -43.53034935969409, "longitude": 173.51210368762364},
-                    {"latitude": -42.894200350955856, "longitude": 172.64076673694242},
-                ],
-                "depth": 40.0,
-                "duration": 60.0,
-                "dt": 0.005,
-            },
+            "domain": domain_parameters.to_dict(),
             "srf": {
                 "genslip_dt": 1.0,
                 "genslip_seed": 1,

--- a/workflow/default_parameters/develop/defaults.yaml
+++ b/workflow/default_parameters/develop/defaults.yaml
@@ -1,9 +1,9 @@
 emod3d:
-  all_in_one: 1
+  all_in_one: true
   bfilt: 4
-  bforce: 0
+  bforce: false
   dampwidth: 0
-  dblcpl: 0
+  dblcpl: false
   dmodfile: rho3dfile.d
   dtts: 20
   dump_itinc: 4000
@@ -13,16 +13,16 @@ emod3d:
   dyts: 5
   dzout: 1
   dzts: 1
-  elas_only: 0
-  enable_output_dump: 1
-  enable_restart: 1
+  elas_only: false
+  enable_output_dump: true
+  enable_restart: true
   ffault: 2
   fhi: 0.0
   fmax: 25.0
   fmin: 0.01
-  freesurf: 1
-  geoproj: 1
-  intmem: 1
+  freesurf: true
+  geoproj: true
+  intmem: true
   ix_ts: 99
   ix_ys: 100
   ix_zs: 100
@@ -32,33 +32,33 @@ emod3d:
   iz_ts: 1
   iz_xs: 1
   iz_ys: 1
-  lonlat_out: 1
+  lonlat_out: true
   maxmem: 1500
   model_style: 1
   nseis: 1
   order: 4
   pmodfile: vp3dfile.p
-  pointmt: 0
+  pointmt: false
   qbndmax: 100.0
   qpfrac: 100.0
   qpqs_factor: 2.0
   qsfrac: 50.0
-  read_restart: 0
+  read_restart: false
   report: 100
   restart_itinc: 20000
   scale: 1
   smodfile: vs3dfile.s
   span: 1
   stype: 2tri-p10-h20
-  swap_bytes: 0
+  swap_bytes: false
   ts_inc: 1
   ts_start: 0
   ts_total: 218
-  ts_xy: 1
-  ts_xz: 0
-  ts_yz: 0
+  ts_xy: true
+  ts_xz: false
+  ts_yz: false
   tzero: 0.6
-  vmodel_swapb: 0
+  vmodel_swapb: false
   xseis: 0
   yseis: 0
   zseis: 0

--- a/workflow/default_parameters/v24_2_2_1/defaults.yaml
+++ b/workflow/default_parameters/v24_2_2_1/defaults.yaml
@@ -1,9 +1,9 @@
 emod3d:
-  all_in_one: 1
+  all_in_one: true
   bfilt: 4
-  bforce: 0
+  bforce: false
   dampwidth: 0
-  dblcpl: 0
+  dblcpl: false
   dmodfile: rho3dfile.d
   dtts: 20
   dump_itinc: 4000
@@ -13,16 +13,16 @@ emod3d:
   dyts: 5
   dzout: 1
   dzts: 1
-  elas_only: 0
-  enable_output_dump: 1
-  enable_restart: 1
+  elas_only: false
+  enable_output_dump: true
+  enable_restart: true
   ffault: 2
   fhi: 0.0
   fmax: 25.0
   fmin: 0.01
-  freesurf: 1
-  geoproj: 1
-  intmem: 1
+  freesurf: true
+  geoproj: true
+  intmem: true
   ix_ts: 99
   ix_ys: 100
   ix_zs: 100
@@ -32,33 +32,33 @@ emod3d:
   iz_ts: 1
   iz_xs: 1
   iz_ys: 1
-  lonlat_out: 1
+  lonlat_out: true
   maxmem: 1500
   model_style: 1
   nseis: 1
   order: 4
   pmodfile: vp3dfile.p
-  pointmt: 0
+  pointmt: false
   qbndmax: 100.0
   qpfrac: 100.0
   qpqs_factor: 2.0
   qsfrac: 50.0
-  read_restart: 0
+  read_restart: false
   report: 100
   restart_itinc: 20000
   scale: 1
   smodfile: vs3dfile.s
   span: 1
   stype: 2tri-p10-h20
-  swap_bytes: 0
+  swap_bytes: false
   ts_inc: 1
   ts_start: 0
   ts_total: 218
-  ts_xy: 1
-  ts_xz: 0
-  ts_yz: 0
+  ts_xy: true
+  ts_xz: false
+  ts_yz: false
   tzero: 0.6
-  vmodel_swapb: 0
+  vmodel_swapb: false
   xseis: 0
   yseis: 0
   zseis: 0

--- a/workflow/default_parameters/v24_2_2_2/defaults.yaml
+++ b/workflow/default_parameters/v24_2_2_2/defaults.yaml
@@ -1,9 +1,9 @@
 emod3d:
-  all_in_one: 1
+  all_in_one: true
   bfilt: 4
-  bforce: 0
+  bforce: false
   dampwidth: 0
-  dblcpl: 0
+  dblcpl: false
   dmodfile: rho3dfile.d
   dtts: 20
   dump_itinc: 4000
@@ -13,16 +13,16 @@ emod3d:
   dyts: 5
   dzout: 1
   dzts: 1
-  elas_only: 0
-  enable_output_dump: 1
-  enable_restart: 1
+  elas_only: false
+  enable_output_dump: true
+  enable_restart: true
   ffault: 2
   fhi: 0.0
   fmax: 25.0
   fmin: 0.01
-  freesurf: 1
-  geoproj: 1
-  intmem: 1
+  freesurf: true
+  geoproj: true
+  intmem: true
   ix_ts: 99
   ix_ys: 100
   ix_zs: 100
@@ -32,33 +32,33 @@ emod3d:
   iz_ts: 1
   iz_xs: 1
   iz_ys: 1
-  lonlat_out: 1
+  lonlat_out: true
   maxmem: 1500
   model_style: 1
   nseis: 1
   order: 4
   pmodfile: vp3dfile.p
-  pointmt: 0
+  pointmt: false
   qbndmax: 100.0
   qpfrac: 100.0
   qpqs_factor: 2.0
   qsfrac: 50.0
-  read_restart: 0
+  read_restart: false
   report: 100
   restart_itinc: 20000
   scale: 1
   smodfile: vs3dfile.s
   span: 1
   stype: 2tri-p10-h20
-  swap_bytes: 0
+  swap_bytes: false
   ts_inc: 1
   ts_start: 0
   ts_total: 218
-  ts_xy: 1
-  ts_xz: 0
-  ts_yz: 0
+  ts_xy: true
+  ts_xz: false
+  ts_yz: false
   tzero: 0.6
-  vmodel_swapb: 0
+  vmodel_swapb: false
   xseis: 0
   yseis: 0
   zseis: 0

--- a/workflow/default_parameters/v24_2_2_4/defaults.yaml
+++ b/workflow/default_parameters/v24_2_2_4/defaults.yaml
@@ -1,9 +1,9 @@
 emod3d:
-  all_in_one: 1
+  all_in_one: true
   bfilt: 4
-  bforce: 0
+  bforce: false
   dampwidth: 0
-  dblcpl: 0
+  dblcpl: false
   dmodfile: rho3dfile.d
   dtts: 20
   dump_itinc: 4000
@@ -13,16 +13,16 @@ emod3d:
   dyts: 5
   dzout: 1
   dzts: 1
-  elas_only: 0
-  enable_output_dump: 1
-  enable_restart: 1
+  elas_only: false
+  enable_output_dump: true
+  enable_restart: true
   ffault: 2
   fhi: 0.0
   fmax: 25.0
   fmin: 0.01
-  freesurf: 1
-  geoproj: 1
-  intmem: 1
+  freesurf: true
+  geoproj: true
+  intmem: true
   ix_ts: 99
   ix_ys: 100
   ix_zs: 100
@@ -32,33 +32,33 @@ emod3d:
   iz_ts: 1
   iz_xs: 1
   iz_ys: 1
-  lonlat_out: 1
+  lonlat_out: true
   maxmem: 1500
   model_style: 1
   nseis: 1
   order: 4
   pmodfile: vp3dfile.p
-  pointmt: 0
+  pointmt: false
   qbndmax: 100.0
   qpfrac: 100.0
   qpqs_factor: 2.0
   qsfrac: 50.0
-  read_restart: 0
+  read_restart: false
   report: 100
   restart_itinc: 20000
   scale: 1
   smodfile: vs3dfile.s
   span: 1
   stype: 2tri-p10-h20
-  swap_bytes: 0
+  swap_bytes: false
   ts_inc: 1
   ts_start: 0
   ts_total: 218
-  ts_xy: 1
-  ts_xz: 0
-  ts_yz: 0
+  ts_xy: true
+  ts_xz: false
+  ts_yz: false
   tzero: 0.6
-  vmodel_swapb: 0
+  vmodel_swapb: false
   xseis: 0
   yseis: 0
   zseis: 0
@@ -118,7 +118,22 @@ velocity_model:
   topo_type: "SQUASHED_TAPERED"
   vs30: 500.0
   s_wave_velocity: 3500.0
-  pgv_interpolants: [[3.5, 0.015], [4.1, 0.0375], [4.7, 0.075], [5.2, 0.15], [5.5, 0.25], [5.8, 0.4], [6.2, 0.7], [6.5, 1.0], [6.8, 1.35], [7.0, 1.65], [7.4, 2.1], [7.7, 2.5], [8.0, 3.0]]
+  pgv_interpolants:
+    [
+      [3.5, 0.015],
+      [4.1, 0.0375],
+      [4.7, 0.075],
+      [5.2, 0.15],
+      [5.5, 0.25],
+      [5.8, 0.4],
+      [6.2, 0.7],
+      [6.5, 1.0],
+      [6.8, 1.35],
+      [7.0, 1.65],
+      [7.4, 2.1],
+      [7.7, 2.5],
+      [8.0, 3.0],
+    ]
 bb:
   flo: 0.5
   dt: 0.02

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -448,99 +448,6 @@ class HFConfig(RealisationConfiguration):
     dt: float
     """High frequency time resolution."""
     nbu: int
-    """Unknown!"""
-    ift: int
-    """Unknown!"""
-    flo: float
-    """Unknown!"""
-    fhi: float
-    """Unknown!"""
-    nl_skip: int
-    """Skip empty lines in input?"""
-    vp_sig: float
-    """Unknown!"""
-    vsh_sig: float
-    """Unknown!"""
-    qs_sig: float
-    """Unknown!"""
-    rho_sig: float
-    """Unknown!"""
-    ic_flag: bool
-    """Unknown!"""
-    velocity_name: str
-    """Unknown"""
-    t_sec: float
-    """High frequency output start time."""
-    sdrop: float
-    """Stress drop average (bars)"""
-    rayset: list[Literal[1, 2]]
-    """ray types 1: direct, 2: moho"""
-    no_siteamp: bool
-    """Disable BJ97 site amplification factors"""
-    fmax: float
-    """Max simulation frequency"""
-    kappa: float
-    """Unknown!"""
-    qfexp: float
-    """Q frequency exponent"""
-    rvfac: float
-    """Rupture velocity factor (rupture : Vs)"""
-    rvfac_shal: float
-    """rvfac shallow fault multiplier"""
-    rvfac_deep: float
-    """rvfac deep fault multiplier"""
-    seed: int
-    """HF seed."""
-    czero: float
-    """C0 coefficient"""
-    calpha: float
-    """Ca coefficient"""
-    mom: Optional[float]
-    """Seismic moment for HF simulation (or None, to infer value)"""
-    rupv: Optional[float]
-    """Rupture velocity (or binary default)"""
-    site_specific: bool
-    """Enable site-specific calculation"""
-    vs_moho: float
-    """vs of moho layer"""
-    fa_sig1: float
-    """Fourier amplitude uncertainty (1)"""
-    fa_sig2: float
-    """Fourier amplitude uncertainty (2)"""
-    rv_sig1: float
-    """Rupture velocity uncertainty"""
-    path_dur: Literal[0, 1, 2, 11, 12]
-    """path duration model.
-        - 0: GP2010
-        - 1: WUS modification trail/error
-        - 2: ENA modification trial/error
-        - 11: WUS formulation of BT2014
-        - 12: ENA formulation of BT2015. Models 11 and 12 over predict for multiple rays."""
-    dpath_pert: float
-    """Log of path duration multiplier"""
-    stress_parameter_adjustment_tect_type: Literal[0, 1, 2]
-    """Adjustment option 0 = off, 1 = active tectonic, 2 = stable continent"""
-    stress_parameter_adjustment_target_magnitude: Optional[float]
-    """Target magnitude (or inferred if None)"""
-    stress_parameter_adjustment_fault_area: Optional[float]
-    """Target magnitude (or inferred if None)"""
-    # these are used in stoch generation, rather than HF invocation
-    stoch_dx: float
-    """stoch file resolution in x."""
-    stoch_dy: float
-    """stoch file resolution in x."""
-
-
-@dataclasses.dataclass
-class EMOD3DParameters(RealisationConfiguration):
-    """Parameters for EMOD3D LF simulation."""
-
-    _config_key: ClassVar[str] = "emod3d"
-    _schema: ClassVar[Schema] = schemas.EMOD3D_PARAMETERS_SCHEMA
-
-    dt: float
-    """High frequency time resolution."""
-    nbu: int
     """Order of butterworth filter used."""
     ift: int
     """Flag for the kind of butterworth filter to apply."""
@@ -623,6 +530,136 @@ class EMOD3DParameters(RealisationConfiguration):
     """Stochastic file resolution in x."""
     stoch_dy: float
     """Stochastic file resolution in y."""
+
+
+@dataclasses.dataclass
+class EMOD3DParameters(RealisationConfiguration):
+    """Parameters for EMOD3D LF simulation."""
+
+    _config_key: ClassVar[str] = "emod3d"
+    _schema: ClassVar[Schema] = schemas.EMOD3D_PARAMETERS_SCHEMA
+
+    all_in_one: int
+    """Unknown!"""
+    bfilt: int
+    """Unknown!"""
+    bforce: int
+    """Unknown!"""
+    dampwidth: int
+    """Width of damping region"""
+    dblcpl: int
+    """Unknown!"""
+    dmodfile: str
+    """Path to density file"""
+    dtts: int
+    """dt per timeslice"""
+    dump_itinc: int
+    """Dump iteration increment"""
+    dxout: int
+    """Unknown!"""
+    dxts: int
+    """dx per timeslice"""
+    dyout: int
+    """Unknown!"""
+    dyts: int
+    """dy per timeslice"""
+    dzout: int
+    """Unknown!"""
+    dzts: int
+    """dz per timeslice"""
+    elas_only: int
+    """If non-zero, perform elastic calculations"""
+    enable_output_dump: int
+    """Unknown!"""
+    enable_restart: int
+    """Enable checkpoints"""
+    ffault: int
+    """If non-zero, source is a finite fault"""
+    fhi: float
+    """High-frequency cutoff?"""
+    fmax: float
+    """Maximum simulation frequency"""
+    fmin: float
+    """Minimum simulation frequency"""
+    freesurf: int
+    """Damping boundary relatod, 0 for absorbing"""
+    geoproj: int
+    """Geographic projection to use"""
+    intmem: int
+    """Unknown!"""
+    ix_ts: int
+    """Timeslice offset for ix?"""
+    ix_ys: int
+    ix_zs: int
+    iy_ts: int
+    iy_xs: int
+    iy_zs: int
+    iz_ts: int
+    iz_xs: int
+    iz_ys: int
+    lonlat_out: int
+    """Unknown!"""
+    maxmem: int
+    """Maximum memory usage in Mb"""
+    model_style: int
+    """Model type for simulation, 0 = 1d, 1 = 3d VM, 2 = 1d VM with 3d pertubations, 3 = 3d VM with 3d perturbations"""
+    nseis: int
+    """Individual points? (from the EMOD3D wiki page)"""
+    order: int
+    """Spatial differencing order"""
+    pmodfile: str
+    """Point to Vp file."""
+    pointmt: int
+    """Unknown!"""
+    qbndmax: float
+    """Unknown!"""
+    qpfrac: float
+    """Multiplier from Vp to Qp"""
+    qpqs_factor: float
+    """Ratio between qpfrac and qsfrac"""
+    qsfrac: float
+    """Multiplier from Vs to Qs"""
+    read_restart: int
+    """Read from checkpoint files?"""
+    report: int
+    """Unknown!"""
+    restart_itinc: int
+    """Checkpoint iteration increment?"""
+    scale: int
+    """Unknown!"""
+    smodfile: str
+    """Path to vs file"""
+    span: int
+    """Unknown!"""
+    stype: str
+    """Unknown!"""
+    swap_bytes: int
+    """Endianness?"""
+    ts_inc: int
+    """Unknown!"""
+    ts_start: int
+    """Unknown!"""
+    ts_total: int
+    """Unknown!"""
+    ts_xy: int
+    """Unknown!"""
+    ts_xz: int
+    """Unknown!"""
+    ts_yz: int
+    """Unknown!"""
+    tzero: float
+    """Start time offset"""
+    vmodel_swapb: int
+    """Velocity model endianness"""
+    xseis: int
+    """Unknown!"""
+    yseis: int
+    """Unknown!"""
+    zseis: int
+    """Unknown!"""
+    pertbfile: str
+    """Path to pertubation file"""
+
 
 @dataclasses.dataclass
 class BroadbandParameters(RealisationConfiguration):

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -17,10 +17,11 @@ from typing import Any, ClassVar, Literal, Optional, Self, Union
 import numpy as np
 import numpy.typing as npt
 from schema import Schema
+from velocity_modelling.bounding_box import BoundingBox
+
 from source_modelling import sources
 from source_modelling.rupture_propagation import JumpPair
 from source_modelling.sources import IsSource
-from velocity_modelling.bounding_box import BoundingBox
 from workflow import defaults, schemas
 from workflow.defaults import DefaultsVersion
 

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -538,127 +538,91 @@ class EMOD3DParameters(RealisationConfiguration):
     _config_key: ClassVar[str] = "emod3d"
     _schema: ClassVar[Schema] = schemas.EMOD3D_PARAMETERS_SCHEMA
 
-    all_in_one: int
-    """Unknown!"""
-    bfilt: int
-    """Unknown!"""
-    bforce: int
-    """Unknown!"""
-    dampwidth: int
-    """Width of damping region"""
-    dblcpl: int
-    """Unknown!"""
-    dmodfile: str
-    """Path to density file"""
-    dtts: int
-    """dt per timeslice"""
-    dump_itinc: int
-    """Dump iteration increment"""
-    dxout: int
-    """Unknown!"""
-    dxts: int
-    """dx per timeslice"""
-    dyout: int
-    """Unknown!"""
-    dyts: int
-    """dy per timeslice"""
-    dzout: int
-    """Unknown!"""
-    dzts: int
-    """dz per timeslice"""
-    elas_only: int
-    """If non-zero, perform elastic calculations"""
-    enable_output_dump: int
-    """Unknown!"""
-    enable_restart: int
-    """Enable checkpoints"""
-    ffault: int
-    """If non-zero, source is a finite fault"""
+    dt: float
+    """High frequency time resolution."""
+    nbu: int
+    """Order of butterworth filter used."""
+    ift: int
+    """Flag for the kind of butterworth filter to apply."""
+    flo: float
+    """Low frequency cutoff."""
     fhi: float
-    """High-frequency cutoff?"""
+    """High frequency cutoff."""
+    nl_skip: int
+    """Skip empty lines in input."""
+    vp_sig: float
+    """Standard deviation for perturbation of P-wave velocity."""
+    vsh_sig: float
+    """Standard deviation for perturbation of S-wave velocity."""
+    qs_sig: float
+    """Standard deviation for perturbation of quality factor for S-waves."""
+    rho_sig: float
+    """Standard deviation for perturbation of density."""
+    ic_flag: bool
+    """Correlation flag.
+    if ic_flag=1, all vel, den & q variations are exactly correlated,
+    if ic_flag=0, vel, den & q variations are completely un-correlated."""
+    velocity_name: str
+    """Name of the velocity model file."""
+    t_sec: float
+    """High frequency output start time."""
+    sdrop: float
+    """Stress drop average (bars)"""
+    rayset: list[Literal[1, 2]]
+    """Ray types 1: direct, 2: moho"""
+    no_siteamp: bool
+    """Disable BJ97 site amplification factors"""
     fmax: float
-    """Maximum simulation frequency"""
-    fmin: float
-    """Minimum simulation frequency"""
-    freesurf: int
-    """Damping boundary relatod, 0 for absorbing"""
-    geoproj: int
-    """Geographic projection to use"""
-    intmem: int
-    """Unknown!"""
-    ix_ts: int
-    """Timeslice offset for ix?"""
-    ix_ys: int
-    ix_zs: int
-    iy_ts: int
-    iy_xs: int
-    iy_zs: int
-    iz_ts: int
-    iz_xs: int
-    iz_ys: int
-    lonlat_out: int
-    """Unknown!"""
-    maxmem: int
-    """Maximum memory usage in Mb"""
-    model_style: int
-    """Model type for simulation, 0 = 1d, 1 = 3d VM, 2 = 1d VM with 3d pertubations, 3 = 3d VM with 3d perturbations"""
-    nseis: int
-    """Individual points? (from the EMOD3D wiki page)"""
-    order: int
-    """Spatial differencing order"""
-    pmodfile: str
-    """Point to Vp file."""
-    pointmt: int
-    """Unknown!"""
-    qbndmax: float
-    """Unknown!"""
-    qpfrac: float
-    """Multiplier from Vp to Qp"""
-    qpqs_factor: float
-    """Ratio between qpfrac and qsfrac"""
-    qsfrac: float
-    """Multiplier from Vs to Qs"""
-    read_restart: int
-    """Read from checkpoint files?"""
-    report: int
-    """Unknown!"""
-    restart_itinc: int
-    """Checkpoint iteration increment?"""
-    scale: int
-    """Unknown!"""
-    smodfile: str
-    """Path to vs file"""
-    span: int
-    """Unknown!"""
-    stype: str
-    """Unknown!"""
-    swap_bytes: int
-    """Endianness?"""
-    ts_inc: int
-    """Unknown!"""
-    ts_start: int
-    """Unknown!"""
-    ts_total: int
-    """Unknown!"""
-    ts_xy: int
-    """Unknown!"""
-    ts_xz: int
-    """Unknown!"""
-    ts_yz: int
-    """Unknown!"""
-    tzero: float
-    """Start time offset"""
-    vmodel_swapb: int
-    """Velocity model endianness"""
-    xseis: int
-    """Unknown!"""
-    yseis: int
-    """Unknown!"""
-    zseis: int
-    """Unknown!"""
-    pertbfile: str
-    """Path to pertubation file"""
-
+    """Max simulation frequency"""
+    kappa: float
+    """Kappa parameter for high-frequency attenuation."""
+    qfexp: float
+    """Q frequency exponent"""
+    rvfac: float
+    """Rupture velocity factor (rupture : Vs)"""
+    rvfac_shal: float
+    """Rupture velocity factor for shallow faults"""
+    rvfac_deep: float
+    """Rupture velocity factor for deep faults"""
+    seed: int
+    """HF seed."""
+    czero: float
+    """C0 coefficient"""
+    calpha: float
+    """Ca coefficient"""
+    mom: Optional[float]
+    """Seismic moment for HF simulation (or None, to infer value)"""
+    rupv: Optional[float]
+    """Rupture velocity (or binary default)"""
+    site_specific: bool
+    """Enable site-specific calculation"""
+    vs_moho: float
+    """Shear wave velocity of the Moho layer"""
+    fa_sig1: float
+    """Fourier amplitude uncertainty (1)"""
+    fa_sig2: float
+    """Fourier amplitude uncertainty (2)"""
+    rv_sig1: float
+    """Rupture velocity uncertainty"""
+    path_dur: Literal[0, 1, 2, 11, 12]
+    """Path duration model.
+        - 0: GP2010
+        - 1: WUS modification trial/error
+        - 2: ENA modification trial/error
+        - 11: WUS formulation of BT2014
+        - 12: ENA formulation of BT2015. Models 11 and 12 over predict for multiple rays."""
+    dpath_pert: float
+    """Log of path duration multiplier"""
+    stress_parameter_adjustment_tect_type: Literal[0, 1, 2]
+    """Adjustment option 0 = off, 1 = active tectonic, 2 = stable continent"""
+    stress_parameter_adjustment_target_magnitude: Optional[float]
+    """Target magnitude (or inferred if None)"""
+    stress_parameter_adjustment_fault_area: Optional[float]
+    """Fault area for stress parameter adjustment (or inferred if None)"""
+    stoch_dx: float
+    """Stochastic file resolution in x."""
+    stoch_dy: float
+    """Stochastic file resolution in y."""
 
 @dataclasses.dataclass
 class BroadbandParameters(RealisationConfiguration):

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -17,11 +17,10 @@ from typing import Any, ClassVar, Literal, Optional, Self, Union
 import numpy as np
 import numpy.typing as npt
 from schema import Schema
-from velocity_modelling.bounding_box import BoundingBox
-
 from source_modelling import sources
 from source_modelling.rupture_propagation import JumpPair
 from source_modelling.sources import IsSource
+from velocity_modelling.bounding_box import BoundingBox
 from workflow import defaults, schemas
 from workflow.defaults import DefaultsVersion
 
@@ -539,15 +538,15 @@ class EMOD3DParameters(RealisationConfiguration):
     _config_key: ClassVar[str] = "emod3d"
     _schema: ClassVar[Schema] = schemas.EMOD3D_PARAMETERS_SCHEMA
 
-    all_in_one: int
+    all_in_one: bool
     """Handles the option to output all-in-one seismograms."""
-    bfilt: int
+    bfilt: bool
     """Indicates whether bandpass filtering is applied."""
-    bforce: int
+    bforce: bool
     """If non-zero, applies body force source."""
     dampwidth: int
     """Width of damping region"""
-    dblcpl: int
+    dblcpl: bool
     """Specifies double couple source."""
     dmodfile: str
     """Path to the density file."""
@@ -569,11 +568,11 @@ class EMOD3DParameters(RealisationConfiguration):
     """dz per timeslice"""
     elas_only: int
     """If non-zero, perform elastic calculations"""
-    enable_output_dump: int
+    enable_output_dump: bool
     """Unknown!"""
-    enable_restart: int
+    enable_restart: bool
     """Enable checkpoints"""
-    ffault: int
+    ffault: bool
     """If non-zero, source is a finite fault"""
     fhi: float
     """High-frequency cutoff."""
@@ -581,11 +580,11 @@ class EMOD3DParameters(RealisationConfiguration):
     """Maximum simulation frequency"""
     fmin: float
     """Minimum simulation frequency"""
-    freesurf: int
+    freesurf: bool
     """Boundary condition: 0 for absorbing, 1 for free surface."""
-    geoproj: int
+    geoproj: bool
     """Geographic projection to use"""
-    intmem: int
+    intmem: bool
     """Internal memory flag for model storage."""
     ix_ts: int
     """Timeslice offset for ix?"""
@@ -597,7 +596,7 @@ class EMOD3DParameters(RealisationConfiguration):
     iz_ts: int
     iz_xs: int
     iz_ys: int
-    lonlat_out: int
+    lonlat_out: bool
     """Output coordinates in longitude and latitude."""
     maxmem: int
     """Maximum memory usage in Mb"""
@@ -609,7 +608,7 @@ class EMOD3DParameters(RealisationConfiguration):
     """Spatial differencing order"""
     pmodfile: str
     """Point to Vp file."""
-    pointmt: int
+    pointmt: bool
     """Point moment tensor source flag."""
     qbndmax: float
     """Maximum boundary quality factor."""
@@ -619,7 +618,7 @@ class EMOD3DParameters(RealisationConfiguration):
     """Ratio between qpfrac and qsfrac"""
     qsfrac: float
     """Multiplier from Vs to Qs"""
-    read_restart: int
+    read_restart: bool
     """Read from checkpoint files."""
     report: int
     """Reporting interval for usage."""
@@ -633,7 +632,7 @@ class EMOD3DParameters(RealisationConfiguration):
     """Number of time steps per I/O operation."""
     stype: str
     """Source time function type."""
-    swap_bytes: int
+    swap_bytes: bool
     """Endianness for file I/O."""
     ts_inc: int
     """Time slice increment."""
@@ -641,15 +640,15 @@ class EMOD3DParameters(RealisationConfiguration):
     """Start time for time slices."""
     ts_total: int
     """Total number of time slices."""
-    ts_xy: int
+    ts_xy: bool
     """Enable XY time slices."""
-    ts_xz: int
+    ts_xz: bool
     """Enable XZ time slices."""
-    ts_yz: int
+    ts_yz: bool
     """Enable YZ time slices."""
     tzero: float
     """Start time offset"""
-    vmodel_swapb: int
+    vmodel_swapb: bool
     """Velocity model endianness"""
     xseis: int
     """Unknown!"""

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -1,0 +1,712 @@
+"""The realisations module defines the schema for the realisation file format.
+
+The configuration schemas are contained in `_REALISATION_SCHEMAS`. The
+schemas loosely validates the input data. Input bounds checking is
+done directly with the schema. More complicated input checking (for
+example, that the rupture propagation defines a tree with one root
+node) should be done outside this module. This is to avoid having this
+module become an "everything" module.
+"""
+
+import dataclasses
+import json
+from abc import ABC
+from pathlib import Path
+from typing import Any, ClassVar, Literal, Optional, Self, Union
+
+import numpy as np
+import numpy.typing as npt
+from schema import Schema
+from velocity_modelling.bounding_box import BoundingBox
+
+from source_modelling import sources
+from source_modelling.rupture_propagation import JumpPair
+from source_modelling.sources import IsSource
+from workflow import defaults, schemas
+from workflow.defaults import DefaultsVersion
+
+
+def to_name_coordinate_dictionary(
+    coordinate_array: npt.NDArray[np.float64],
+    coordinate_names: list[str] = ["latitude", "longitude", "depth"],
+) -> Union[dict[str, float], list[dict[str, float]]]:
+    """Convert an array of coordinates values into a (list of) dictionaries tagged with coordinate names.
+
+    Parameters
+    ----------
+    coordinate_array : np.ndarray
+        The array of values. Should have shape (k,), (m, k) where k is at most the length of `coordinate_names`.
+    coordinate_names : list[str]
+        The names of the coordinates. Defaults to ['latitude', 'longitude', 'depth'].
+
+    Returns
+    -------
+    dict[str, float] or list[dict[str, float]]
+        Either a dictionary with keys 'latitude', 'longitude', 'depth'
+        or a list of dictionaries with the same keys. The single
+        dictionary is returned only if the input is one-dimensional.
+
+    Examples
+    --------
+    >>> to_name_coordinate_dictionary(np.array([1, 0]), coordinate_names=['s', 'd'])
+    {'s': 1, 'd': 0}
+    >>> to_name_coordinate_dictionary(np.array([0, 0, 1000]))
+    {'latitude': 0, 'longitude': 0, 'depth': 1000}
+    """
+    coordinate_dicts = [
+        dict(zip(coordinate_names, coordinate_array.tolist()))
+        for coordinate_array in np.atleast_2d(coordinate_array)
+    ]
+
+    if len(coordinate_array.shape) == 1:
+        return coordinate_dicts[0]
+
+    return coordinate_dicts
+
+
+class RealisationParseError(Exception):
+    """Realisation JSON parse error."""
+
+    pass
+
+
+@dataclasses.dataclass
+class RealisationConfiguration(ABC):
+    """Abstract base class for RealisationConfiguration."""
+
+    _config_key: ClassVar[str]
+    """The configuration key to save and load from in the realisation."""
+    _schema: ClassVar[Schema]
+    """The reference schema to validate against when reading from a realisation."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Convert the object to a dictionary representation.
+
+        Returns
+        -------
+        dict
+            Dictionary representation of the object.
+        """
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def read_from_realisation(cls, realisation_ffp: Path) -> Self:
+        """Read configuration from a realisation file.
+
+        Parameters
+        ----------
+        realisation_ffp : Path
+            The filepath to read from.
+
+        Returns
+        -------
+        RealisationConfiguration
+            The configuration loaded from the realisation filepath. The
+            configuration schema is looked up from `cls._config_key`
+            and the key within the config is specified
+            `cls._schema`.
+
+        Raises
+        ------
+        RealisationParseError
+            If the key in `cls._config_key` is not present in
+            the realisation filepath.
+        """
+        with open(realisation_ffp, "r", encoding="utf-8") as realisation_file_handle:
+            realisation_config = json.load(realisation_file_handle)
+            if cls._config_key not in realisation_config:
+                raise RealisationParseError(
+                    f"No {cls._config_key} in realisation configuration"
+                )
+        return cls(**cls._schema.validate(realisation_config[cls._config_key]))
+
+    @classmethod
+    def read_from_defaults(cls, defaults_version: DefaultsVersion) -> Self:
+        """Read default values for this configuration.
+
+        Parameters
+        ----------
+        defaults_version : DefaultsVersion
+            The default parameter version to load with.
+
+        Returns
+        -------
+        RealisationConfiguration
+            The configuration loaded from the defaults. The configuration
+            schema is looked up from `cls._config_key` and the key within
+            the config is specified `cls._schema`.
+
+        Raises
+        ------
+        RealisationParseError
+            If the key in `cls._config_key` is not present in the scientific
+            defaults configuration.
+        """
+        default_config = defaults.load_defaults(defaults_version)
+        if cls._config_key not in default_config:
+            raise RealisationParseError(
+                f"No {cls._config_key} in defaults configuration"
+            )
+        return cls(**cls._schema.validate(default_config[cls._config_key]))
+
+    @classmethod
+    def read_from_realisation_or_defaults(
+        cls, realisation_ffp: Path, defaults_version: DefaultsVersion
+    ) -> Self:
+        """Read configuration from realisation, or read from defaults and write to realisation.
+
+        Parameters
+        ----------
+        defaults_version : DefaultsVersion
+            The default parameter version to load with.
+
+        Returns
+        -------
+        RealisationConfiguration
+            The configuration loaded from the realisation filepath, or the
+            defaults if the realisation does not contain the configuration
+            key. The configuration schema is looked up from `cls._config_key`
+            and the key within the config is specified `cls._schema`.
+
+        Raises
+        ------
+        RealisationParseError
+            If the key in `cls._config_key` is not present in
+            the realisation or scientific defaults configuration.
+        """
+        try:
+            return cls.read_from_realisation(realisation_ffp)
+        except RealisationParseError:
+            default_config = cls.read_from_defaults(defaults_version)
+            default_config.write_to_realisation(realisation_ffp)
+            return default_config
+
+    def write_to_realisation(self, realisation_ffp: Path, update: bool = True) -> None:
+        """Write a configuration to a realisation file.
+
+        The default behaviour will update the realisation and replace just
+        the configuration keys specified by `config`. If `update` is set
+        to False, then the realisation is completely overwritten and
+        populated with only the section pertaining to the config.
+
+        Parameters
+        ----------
+        realisation_ffp : Path
+            The realisation filepath to write to.
+        update : bool
+            If True, then the realisation is updated, rather than
+            replaced. Default is True.
+        """
+        realisation_configuration = {}
+        if realisation_ffp.exists() and update:
+            with open(
+                realisation_ffp, "r", encoding="utf-8"
+            ) as realisation_file_handle:
+                realisation_configuration = json.load(realisation_file_handle)
+        realisation_configuration.update({self._config_key: self.to_dict()})
+        with open(realisation_ffp, "w", encoding="utf-8") as realisation_file_handle:
+            json.dump(realisation_configuration, realisation_file_handle)
+
+
+@dataclasses.dataclass
+class SourceConfig(RealisationConfiguration):
+    """Configuration for defining sources."""
+
+    _config_key: ClassVar[str] = "sources"
+    _schema: ClassVar[Schema] = schemas.SOURCE_SCHEMA
+
+    source_geometries: dict[str, IsSource]
+    """Dictionary mapping source names to their definitions."""
+
+    def to_dict(self):
+        """
+        Convert the object to a dictionary representation.
+
+        Returns
+        -------
+        dict
+            Dictionary representation of the object.
+        """
+        config_dict = {}
+        for name, geometry in self.source_geometries.items():
+            if isinstance(geometry, sources.Point):
+                config_dict[name] = {
+                    "type": "point",
+                    "coordinates": to_name_coordinate_dictionary(geometry.coordinates),
+                    "length": geometry.length_m,
+                    "strike": geometry.strike,
+                    "dip": geometry.dip,
+                    "dip_dir": geometry.dip_dir,
+                }
+            elif isinstance(geometry, sources.Plane):
+                config_dict[name] = {
+                    "type": "plane",
+                    "corners": to_name_coordinate_dictionary(geometry.corners),
+                }
+            elif isinstance(geometry, sources.Fault):
+                config_dict[name] = {
+                    "type": "fault",
+                    "corners": to_name_coordinate_dictionary(geometry.corners),
+                }
+        return {"source_geometries": config_dict}
+
+
+@dataclasses.dataclass
+class SRFConfig(RealisationConfiguration):
+    """Configuration for SRF generation."""
+
+    _config_key: ClassVar[str] = "srf"
+    _schema: ClassVar[Schema] = schemas.SRF_SCHEMA
+
+    genslip_dt: float
+    """The timestep for genslip (used to specify the resolution for the `TINIT` values)."""
+    genslip_seed: int
+    """The random seed passed to genslip."""
+    genslip_version: str
+    """The version of genslip to use (currently supports "5.4.2")."""
+    resolution: float
+    """The resolution of the SRF geometry"""
+    srfgen_seed: int
+    """A second random seed for genslip, used for specific purposes in the generation process."""
+
+
+@dataclasses.dataclass
+class RupturePropagationConfig(RealisationConfiguration):
+    """Configuration for rupture propagation."""
+
+    _config_key: ClassVar[str] = "rupture_propagation"
+    _schema: ClassVar[Schema] = schemas.RUPTURE_PROPAGATION_SCHEMA
+
+    rupture_causality_tree: dict[str, Optional[str]]
+    """A dict where the keys are faults and the values the parent fault (i.e. if fault a triggers fault b then rupture_causality_tree[fault b] = fault a)."""
+    jump_points: dict[str, JumpPair]
+    """A map from faults to pairs of fault-local coordinates representing jump points. If the rupture jumps from fault a at point a to point b on fault b then jump_points[fault a] = JumpPoint(point b, point a)."""
+    rakes: dict[str, float]
+    """A map from faults to rakes."""
+    magnitudes: dict[str, float]
+    """A map from faults to the magnitude of the rupture for each fault."""
+    hypocentre: npt.NDArray[np.float64]
+    """The hypocentre of the fault."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Convert the object to a dictionary representation.
+
+        Returns
+        -------
+        dict
+            Dictionary representation of the object.
+        """
+        config_dict = dataclasses.asdict(self)
+        config_dict["jump_points"] = {
+            fault: {
+                "from_point": to_name_coordinate_dictionary(
+                    jump_point.from_point, ["s", "d"]
+                ),
+                "to_point": to_name_coordinate_dictionary(
+                    jump_point.to_point, ["s", "d"]
+                ),
+            }
+            for fault, jump_point in self.jump_points.items()
+        }
+        config_dict["hypocentre"] = to_name_coordinate_dictionary(
+            self.hypocentre, ["s", "d"]
+        )
+        return config_dict
+
+    @property
+    def initial_fault(self) -> str:
+        """The initial fault in the rupture.
+
+        Returns
+        -------
+        str
+            The initial fault in the rupture.
+        """
+        return next(
+            fault_name
+            for fault_name, parent_name in self.rupture_causality_tree.items()
+            if parent_name is None
+        )
+
+
+@dataclasses.dataclass
+class DomainParameters(RealisationConfiguration):
+    """Parameters defining the spatial and temporal domain for simulation."""
+
+    _config_key: ClassVar[str] = "domain"
+    _schema: ClassVar[Schema] = schemas.DOMAIN_SCHEMA
+
+    resolution: float
+    """The simulation resoultion in kilometres."""
+    domain: BoundingBox
+    """The bounding box for the domain."""
+    depth: float
+    """The depth of the domain (in metres)."""
+    duration: float
+    """The simulation duration (in seconds)."""
+    dt: float
+    """The resolution of the domain in time (in seconds)."""
+
+    @property
+    def nx(self) -> int:
+        """int: The number of x coordinate positions in the discretised domain."""
+        return int(np.round(self.domain.extent_x / self.resolution))
+
+    @property
+    def ny(self) -> int:
+        """int: The number of y coordinate positions in the discretised domain."""
+        return int(np.round(self.domain.extent_y / self.resolution))
+
+    @property
+    def nz(self) -> int:
+        """int: The number of z coordinate positions in the discretised domain."""
+        return int(np.round(self.depth / self.resolution))
+
+    def to_dict(self) -> dict:
+        """
+        Convert the object to a dictionary representation.
+
+        Returns
+        -------
+        dict
+            Dictionary representation of the object.
+        """
+        param_dict = dataclasses.asdict(self)
+        param_dict["domain"] = to_name_coordinate_dictionary(
+            self.domain.corners,
+        )
+        return param_dict
+
+
+@dataclasses.dataclass
+class VelocityModelParameters(RealisationConfiguration):
+    """Parameters defining the velocity model."""
+
+    _config_key: ClassVar[str] = "velocity_model"
+    _schema: ClassVar[Schema] = schemas.VELOCITY_MODEL_SCHEMA
+
+    min_vs: float
+    """The minimum velocity in the velocity model."""
+    version: str
+    """The velocity model version."""
+    topo_type: str
+    """The topology type of the velocity model."""
+    dt: float
+    """The velocity model time resolution."""
+    ds_multiplier: float
+    """The ds multiplier used to adjust simulation duration."""
+    resolution: float
+    """The resolution of the velocity model (in kilometres)."""
+    vs30: float
+    """The reference vs30 value for duration estimation."""
+    s_wave_velocity: float
+    """The s-wave velocity."""
+    pgv_interpolants: npt.NDArray[np.float32]
+    """PGV interpolation nodes between rupture magnitude and PGV target values."""
+
+    def to_dict(self) -> dict:
+        """
+        Convert the object to a dictionary representation.
+
+        Returns
+        -------
+        dict
+            Dictionary representation of the object.
+        """
+        _dict = dataclasses.asdict(self)
+        _dict["pgv_interpolants"] = _dict["pgv_interpolants"].tolist()
+        return _dict
+
+
+@dataclasses.dataclass
+class RealisationMetadata(RealisationConfiguration):
+    """Metadata for describing a realisation."""
+
+    _config_key: ClassVar[str] = "metadata"
+    _schema: ClassVar[Schema] = schemas.REALISATION_METADATA_SCHEMA
+
+    name: str
+    """The name of the realisation."""
+    version: str
+    """The version of the realisation format (currently supports version "1")."""
+    defaults_version: DefaultsVersion
+    """The version of the scientific defaults to use."""
+    tag: Optional[str] = None
+    """Metadata tag for the realisation used to specify the origin or
+    category of the realisation (e.g. NSHM, GCMT or custom)."""
+
+
+@dataclasses.dataclass
+class HFConfig(RealisationConfiguration):
+    """High frequency simulation configuration."""
+
+    _config_key: ClassVar[str] = "hf"
+    _schema: ClassVar[Schema] = schemas.HF_CONFIG_SCHEMA
+
+    dt: float
+    """High frequency time resolution."""
+    nbu: int
+    """Unknown!"""
+    ift: int
+    """Unknown!"""
+    flo: float
+    """Unknown!"""
+    fhi: float
+    """Unknown!"""
+    nl_skip: int
+    """Skip empty lines in input?"""
+    vp_sig: float
+    """Unknown!"""
+    vsh_sig: float
+    """Unknown!"""
+    qs_sig: float
+    """Unknown!"""
+    rho_sig: float
+    """Unknown!"""
+    ic_flag: bool
+    """Unknown!"""
+    velocity_name: str
+    """Unknown"""
+    t_sec: float
+    """High frequency output start time."""
+    sdrop: float
+    """Stress drop average (bars)"""
+    rayset: list[Literal[1, 2]]
+    """ray types 1: direct, 2: moho"""
+    no_siteamp: bool
+    """Disable BJ97 site amplification factors"""
+    fmax: float
+    """Max simulation frequency"""
+    kappa: float
+    """Unknown!"""
+    qfexp: float
+    """Q frequency exponent"""
+    rvfac: float
+    """Rupture velocity factor (rupture : Vs)"""
+    rvfac_shal: float
+    """rvfac shallow fault multiplier"""
+    rvfac_deep: float
+    """rvfac deep fault multiplier"""
+    seed: int
+    """HF seed."""
+    czero: float
+    """C0 coefficient"""
+    calpha: float
+    """Ca coefficient"""
+    mom: Optional[float]
+    """Seismic moment for HF simulation (or None, to infer value)"""
+    rupv: Optional[float]
+    """Rupture velocity (or binary default)"""
+    site_specific: bool
+    """Enable site-specific calculation"""
+    vs_moho: float
+    """vs of moho layer"""
+    fa_sig1: float
+    """Fourier amplitude uncertainty (1)"""
+    fa_sig2: float
+    """Fourier amplitude uncertainty (2)"""
+    rv_sig1: float
+    """Rupture velocity uncertainty"""
+    path_dur: Literal[0, 1, 2, 11, 12]
+    """path duration model.
+        - 0: GP2010
+        - 1: WUS modification trail/error
+        - 2: ENA modification trial/error
+        - 11: WUS formulation of BT2014
+        - 12: ENA formulation of BT2015. Models 11 and 12 over predict for multiple rays."""
+    dpath_pert: float
+    """Log of path duration multiplier"""
+    stress_parameter_adjustment_tect_type: Literal[0, 1, 2]
+    """Adjustment option 0 = off, 1 = active tectonic, 2 = stable continent"""
+    stress_parameter_adjustment_target_magnitude: Optional[float]
+    """Target magnitude (or inferred if None)"""
+    stress_parameter_adjustment_fault_area: Optional[float]
+    """Target magnitude (or inferred if None)"""
+    # these are used in stoch generation, rather than HF invocation
+    stoch_dx: float
+    """stoch file resolution in x."""
+    stoch_dy: float
+    """stoch file resolution in x."""
+
+
+@dataclasses.dataclass
+class EMOD3DParameters(RealisationConfiguration):
+    """Parameters for EMOD3D LF simulation."""
+
+    _config_key: ClassVar[str] = "emod3d"
+    _schema: ClassVar[Schema] = schemas.EMOD3D_PARAMETERS_SCHEMA
+
+    all_in_one: int
+    """Unknown!"""
+    bfilt: int
+    """Unknown!"""
+    bforce: int
+    """Unknown!"""
+    dampwidth: int
+    """Width of damping region"""
+    dblcpl: int
+    """Unknown!"""
+    dmodfile: str
+    """Path to density file"""
+    dtts: int
+    """dt per timeslice"""
+    dump_itinc: int
+    """Dump iteration increment"""
+    dxout: int
+    """Unknown!"""
+    dxts: int
+    """dx per timeslice"""
+    dyout: int
+    """Unknown!"""
+    dyts: int
+    """dy per timeslice"""
+    dzout: int
+    """Unknown!"""
+    dzts: int
+    """dz per timeslice"""
+    elas_only: int
+    """If non-zero, perform elastic calculations"""
+    enable_output_dump: int
+    """Unknown!"""
+    enable_restart: int
+    """Enable checkpoints"""
+    ffault: int
+    """If non-zero, source is a finite fault"""
+    fhi: float
+    """High-frequency cutoff?"""
+    fmax: float
+    """Maximum simulation frequency"""
+    fmin: float
+    """Minimum simulation frequency"""
+    freesurf: int
+    """Damping boundary relatod, 0 for absorbing"""
+    geoproj: int
+    """Geographic projection to use"""
+    intmem: int
+    """Unknown!"""
+    ix_ts: int
+    """Timeslice offset for ix?"""
+    ix_ys: int
+    ix_zs: int
+    iy_ts: int
+    iy_xs: int
+    iy_zs: int
+    iz_ts: int
+    iz_xs: int
+    iz_ys: int
+    lonlat_out: int
+    """Unknown!"""
+    maxmem: int
+    """Maximum memory usage in Mb"""
+    model_style: int
+    """Model type for simulation, 0 = 1d, 1 = 3d VM, 2 = 1d VM with 3d pertubations, 3 = 3d VM with 3d perturbations"""
+    nseis: int
+    """Individual points? (from the EMOD3D wiki page)"""
+    order: int
+    """Spatial differencing order"""
+    pmodfile: str
+    """Point to Vp file."""
+    pointmt: int
+    """Unknown!"""
+    qbndmax: float
+    """Unknown!"""
+    qpfrac: float
+    """Multiplier from Vp to Qp"""
+    qpqs_factor: float
+    """Ratio between qpfrac and qsfrac"""
+    qsfrac: float
+    """Multiplier from Vs to Qs"""
+    read_restart: int
+    """Read from checkpoint files?"""
+    report: int
+    """Unknown!"""
+    restart_itinc: int
+    """Checkpoint iteration increment?"""
+    scale: int
+    """Unknown!"""
+    smodfile: str
+    """Path to vs file"""
+    span: int
+    """Unknown!"""
+    stype: str
+    """Unknown!"""
+    swap_bytes: int
+    """Endianness?"""
+    ts_inc: int
+    """Unknown!"""
+    ts_start: int
+    """Unknown!"""
+    ts_total: int
+    """Unknown!"""
+    ts_xy: int
+    """Unknown!"""
+    ts_xz: int
+    """Unknown!"""
+    ts_yz: int
+    """Unknown!"""
+    tzero: float
+    """Start time offset"""
+    vmodel_swapb: int
+    """Velocity model endianness"""
+    xseis: int
+    """Unknown!"""
+    yseis: int
+    """Unknown!"""
+    zseis: int
+    """Unknown!"""
+    pertbfile: str
+    """Path to pertubation file"""
+
+
+@dataclasses.dataclass
+class BroadbandParameters(RealisationConfiguration):
+    """Parameters for broadband waveform merger."""
+
+    _config_key: ClassVar[str] = "bb"
+    _schema: ClassVar[Schema] = schemas.BROADBAND_PARAMETERS_SCHEMA
+
+    flo: float
+    """low/high frequency cutoff."""
+    dt: float
+    """simulation time resolution."""
+    fmidbot: float
+    """fmidbot for site amplification"""
+    fmin: float
+    """fmin for site amplification."""
+    site_amp_version: str
+
+
+@dataclasses.dataclass
+class IntensityMeasureCalcuationParameters(RealisationConfiguration):
+    """Intensity measure calculation parameters."""
+
+    _config_key: ClassVar[str] = "im"
+    _schema: ClassVar[Schema] = schemas.INTENSITY_MEASURE_CALCUATION_PARAMETERS
+
+    ims: list[schemas.IntensityMeasure]
+    """Intensity measures to calculate."""
+    components: list[schemas.Component]
+    """Components to calculate intensity measures in."""
+    valid_periods: npt.NDArray[np.float64]
+    """Valid periods to calculate for, applicable for pSA and SDI."""
+    fas_frequencies: npt.NDArray[np.float64]
+    """Fourier spectrum frequencies."""
+    units: schemas.Units
+    """Units to calculate intensity measures in."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Convert the object to a dictionary representation.
+
+        Returns
+        -------
+        dict
+            Dictionary representation of the object.
+        """
+        _dict = dataclasses.asdict(self)
+        _dict["components"] = [component.value for component in self.components]
+        _dict["valid_periods"] = self.valid_periods.tolist()
+        _dict["fas_frequencies"] = self.fas_frequencies.tolist()
+        return _dict

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -540,19 +540,19 @@ class EMOD3DParameters(RealisationConfiguration):
     _schema: ClassVar[Schema] = schemas.EMOD3D_PARAMETERS_SCHEMA
 
     all_in_one: int
-    """Unknown!"""
+    """Handles the option to output all-in-one seismograms."""
     bfilt: int
-    """Unknown!"""
+    """Indicates whether bandpass filtering is applied."""
     bforce: int
-    """Unknown!"""
+    """If non-zero, applies body force source."""
     dampwidth: int
     """Width of damping region"""
     dblcpl: int
-    """Unknown!"""
+    """Specifies double couple source."""
     dmodfile: str
-    """Path to density file"""
+    """Path to the density file."""
     dtts: int
-    """dt per timeslice"""
+    """dt per timeslice."""
     dump_itinc: int
     """Dump iteration increment"""
     dxout: int
@@ -576,17 +576,17 @@ class EMOD3DParameters(RealisationConfiguration):
     ffault: int
     """If non-zero, source is a finite fault"""
     fhi: float
-    """High-frequency cutoff?"""
+    """High-frequency cutoff."""
     fmax: float
     """Maximum simulation frequency"""
     fmin: float
     """Minimum simulation frequency"""
     freesurf: int
-    """Damping boundary relatod, 0 for absorbing"""
+    """Boundary condition: 0 for absorbing, 1 for free surface."""
     geoproj: int
     """Geographic projection to use"""
     intmem: int
-    """Unknown!"""
+    """Internal memory flag for model storage."""
     ix_ts: int
     """Timeslice offset for ix?"""
     ix_ys: int
@@ -598,7 +598,7 @@ class EMOD3DParameters(RealisationConfiguration):
     iz_xs: int
     iz_ys: int
     lonlat_out: int
-    """Unknown!"""
+    """Output coordinates in longitude and latitude."""
     maxmem: int
     """Maximum memory usage in Mb"""
     model_style: int
@@ -610,9 +610,9 @@ class EMOD3DParameters(RealisationConfiguration):
     pmodfile: str
     """Point to Vp file."""
     pointmt: int
-    """Unknown!"""
+    """Point moment tensor source flag."""
     qbndmax: float
-    """Unknown!"""
+    """Maximum boundary quality factor."""
     qpfrac: float
     """Multiplier from Vp to Qp"""
     qpqs_factor: float
@@ -620,33 +620,33 @@ class EMOD3DParameters(RealisationConfiguration):
     qsfrac: float
     """Multiplier from Vs to Qs"""
     read_restart: int
-    """Read from checkpoint files?"""
+    """Read from checkpoint files."""
     report: int
-    """Unknown!"""
+    """Reporting interval for usage."""
     restart_itinc: int
-    """Checkpoint iteration increment?"""
+    """Checkpoint iteration increment."""
     scale: int
     """Unknown!"""
     smodfile: str
     """Path to vs file"""
     span: int
-    """Unknown!"""
+    """Number of time steps per I/O operation."""
     stype: str
-    """Unknown!"""
+    """Source time function type."""
     swap_bytes: int
-    """Endianness?"""
+    """Endianness for file I/O."""
     ts_inc: int
-    """Unknown!"""
+    """Time slice increment."""
     ts_start: int
-    """Unknown!"""
+    """Start time for time slices."""
     ts_total: int
-    """Unknown!"""
+    """Total number of time slices."""
     ts_xy: int
-    """Unknown!"""
+    """Enable XY time slices."""
     ts_xz: int
-    """Unknown!"""
+    """Enable XZ time slices."""
     ts_yz: int
-    """Unknown!"""
+    """Enable YZ time slices."""
     tzero: float
     """Start time offset"""
     vmodel_swapb: int
@@ -658,7 +658,7 @@ class EMOD3DParameters(RealisationConfiguration):
     zseis: int
     """Unknown!"""
     pertbfile: str
-    """Path to pertubation file"""
+    """Path to perturbation file."""
 
 
 @dataclasses.dataclass

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -339,7 +339,7 @@ class DomainParameters(RealisationConfiguration):
     _schema: ClassVar[Schema] = schemas.DOMAIN_SCHEMA
 
     resolution: float
-    """The simulation resoultion in kilometres."""
+    """The simulation resolution in kilometres."""
     domain: BoundingBox
     """The bounding box for the domain."""
     depth: float

--- a/workflow/schemas.py
+++ b/workflow/schemas.py
@@ -540,7 +540,7 @@ EMOD3D_PARAMETERS_SCHEMA = Schema(
         Literal(
             "pointmt", description="If true, use a point moment tensor source flag"
         ): bool,
-        Literal("qbndmax", descrption="Maximum boundary quality factor"): float,
+        Literal("qbndmax", description="Maximum boundary quality factor"): float,
         Literal("qpfrac", description="Multiplier from Vp, to Qp"): float,
         Literal("qpqs_factor", description="Ratio between Qp and Qs"): float,
         Literal("qsfrac", description="Ratio between Vs to Qs."): float,

--- a/workflow/schemas.py
+++ b/workflow/schemas.py
@@ -1,0 +1,616 @@
+"""Module containing schema definitions for the realisation specification.
+
+See the `realisations` module, or repository wiki pages (specifically
+the [Realisations page](https://github.com/ucgmsim/workflow/wiki/Realisations), and the
+[Realisations Proposal page](https://github.com/ucgmsim/workflow/wiki/Realisation-Proposal))
+for a description of realisations and the schemas.
+"""
+
+from enum import StrEnum
+
+import numpy as np
+from schema import And, Literal, Optional, Or, Schema, Use
+from velocity_modelling.bounding_box import BoundingBox
+
+from source_modelling import rupture_propagation, sources
+from workflow.defaults import DefaultsVersion
+
+# NOTE: These functions seem silly and short, however there is a good
+# reason for the choice to create functions like this. The reason is
+# because when the schema library reports an error (such as the input
+# file having a negative depth value) it prints the name of the
+# function. So
+#
+# And(float, lambda x: x > 0).validate(-12)
+#
+# Would report the error
+#
+# schema.SchemaError: <lambda>(-12) should evaluate to True
+#
+# But using the function `is_positive` we instead have
+#
+# And(float, is_positive).validate(-12)
+# schema.SchemaError: is_positive(-12) should evaluate to True
+#
+# So using short functions with names improves the error reporting
+# from the library.
+#
+# Accordingly, the most trivial of these functions lack docstrings.
+
+
+def is_positive(x: float) -> bool:  # noqa: D103
+    return x > 0
+
+
+def is_non_negative(x: float) -> bool:  # noqa: D103
+    return x >= 0
+
+
+def is_valid_latitude(latitude: float) -> bool:  # noqa: D103
+    return -90 <= latitude <= 90
+
+
+def is_valid_longitude(longitude: float) -> bool:  # noqa: D103
+    return -180 <= longitude <= 180
+
+
+def is_plausible_magnitude(magnitude: float) -> bool:  # noqa: D103
+    return magnitude < 11
+
+
+def is_valid_degrees(degrees: float) -> bool:  # noqa: D103
+    return -360 <= degrees <= 360
+
+
+def is_valid_local_coordinate(coordinate: float) -> bool:  # noqa: D103
+    return 0 <= coordinate <= 1
+
+
+def is_valid_bearing(bearing: float) -> bool:  # noqa: D103
+    return 0 <= bearing <= 360
+
+
+def is_correct_corner_shape(corners: np.ndarray) -> bool:
+    """Check if the corner shape matches the corner shape for plane sources.
+
+    Parameters
+    ----------
+    corners : np.ndarray
+        The corners to validate
+
+    Returns
+    -------
+    bool
+        True if the corners has the shape (4, 3) (one for each point
+        and three components lat, lon and depth).
+    """
+    return corners.shape == (4, 3)
+
+
+def is_correct_fault_corner_shape(corners: np.ndarray) -> bool:
+    """Check if the corner shape matches the definition of corners for a fault (multi-plane; type-4).
+
+    Parameters
+    ----------
+    corners : np.ndarray
+        The corners to validate
+
+    Returns
+    -------
+    bool
+        True if the corners have shape (n x 4 x 3).
+    """
+    if len(corners.shape) != 3:
+        return False
+    return corners.shape[1:] == (4, 3)
+
+
+def has_non_negative_depth(corners: np.ndarray) -> bool:
+    """Check the depth component of corners array is non-negative.
+
+    Parameters
+    ----------
+    corners : np.ndarray
+        The corners to validate.
+
+    Returns
+    -------
+    bool
+        Returns true if the last column of the corners is
+        non-negative.
+    """
+    return np.all(corners[:, -1] >= 0)
+
+
+def corners_to_array(corners_spec: list[dict[str, float]]) -> np.ndarray:
+    """Convert a list of coordinates to a numpy array in the corner format.
+
+    Parameters
+    ----------
+    corners_spec : list[dict[str, float]]
+        The corners to convert.
+
+    Returns
+    -------
+    np.ndarray
+        An array of shape (n x 3) where columns 0, 1, and 2 correspond
+        to latitude, longitude, and depth respectively.
+    """
+    corners_array = []
+    for corner in corners_spec:
+        if "depth" in corner:
+            corners_array.append(
+                [corner["latitude"], corner["longitude"], corner["depth"]]
+            )
+        else:
+            corners_array.append([corner["latitude"], corner["longitude"]])
+    return np.array(corners_array)
+
+
+FAULT_LOCAL_COORDINATES_SCHEMA = Schema(
+    And(
+        {
+            Literal(
+                "s",
+                description="The `s` coordinate (fraction of length, in range [0, 1])",
+            ): And(float, is_valid_local_coordinate),
+            Literal(
+                "d",
+                description="The `d` coordinate (fraction of width, in range [0, 1])",
+            ): And(float, is_valid_local_coordinate),
+        },
+        Use(lambda local_coords: np.array([local_coords["s"], local_coords["d"]])),
+    )
+)
+
+
+LAT_LON_SCHEMA = Schema(
+    And(
+        {
+            Literal("latitude", description="Latitude (in decimal degrees)"): And(
+                float, is_valid_latitude
+            ),
+            Literal("longitude", description="Longitude (in decimal degrees)"): And(
+                float, is_valid_longitude
+            ),
+        },
+        Use(lambda latlon: np.array([latlon["latitude"], latlon["longitude"]])),
+    ),
+)
+
+LAT_LON_DEPTH_SCHEMA = Schema(
+    And(
+        {
+            Literal("latitude", description="Latitude (in decimal degrees)"): And(
+                float, is_valid_latitude
+            ),
+            Literal("longitude", description="Longitude (in decimal degrees)"): And(
+                float, is_valid_longitude
+            ),
+            Literal("depth", description="Depth (in metres)"): And(
+                float, is_non_negative
+            ),
+        },
+        Use(
+            lambda latlondepth: np.array(
+                [
+                    latlondepth["latitude"],
+                    latlondepth["longitude"],
+                    latlondepth["depth"],
+                ]
+            )
+        ),
+    )
+)
+
+POINT_SCHEMA = Schema(
+    And(
+        {
+            Literal(
+                "type",
+                description="The type of the source geometry (Point, Plane or Fault)",
+            ): "point",
+            Literal(
+                "coordinates", description="The coordinates of the point source"
+            ): LAT_LON_DEPTH_SCHEMA,
+            Literal("length", description="The pseudo-length of the point source"): And(
+                float, is_positive
+            ),
+            Literal(
+                "strike", description="The strike bearing of the point source"
+            ): And(float, is_valid_bearing),
+            Literal("dip", description="The dip angle of the point source"): And(
+                float, is_valid_bearing
+            ),
+            Literal(
+                "dip_dir", description="The dip direction bearing of the point source"
+            ): And(float, is_valid_bearing),
+        },
+        Use(
+            lambda schema: sources.Point.from_lat_lon_depth(
+                schema["coordinates"],
+                length_m=schema["length"],
+                strike=schema["strike"],
+                dip=schema["dip"],
+                dip_dir=schema["dip_dir"],
+            )
+        ),
+    )
+)
+
+PLANE_SCHEMA = Schema(
+    And(
+        {
+            Literal(
+                "type",
+                description="The type of the source geometry (Point, Plane or Fault)",
+            ): "plane",
+            Literal(
+                "corners",
+                description="The corners of the plane (shape 4 x 3: lat, lon, depth)",
+            ): And(
+                Use(corners_to_array), is_correct_corner_shape, has_non_negative_depth
+            ),
+        },
+        Use(lambda schema: sources.Plane.from_corners(schema["corners"])),
+    )
+)
+
+FAULT_SCHEMA = Schema(
+    And(
+        {
+            Literal(
+                "type",
+                description="The type of the source geometry (Point, Plane, or Fault)",
+            ): "fault",
+            Literal(
+                "corners",
+                description="The corners of the plane (shape 4 x n x 3: lat, lon, depth)",
+            ): And(
+                Use(corners_to_array),
+                has_non_negative_depth,
+                Use(
+                    (lambda corners: corners.reshape((-1, 4, 3))),
+                    error="Corners cannot be reshaped to (n x 4 x 3).",
+                ),
+            ),
+        },
+        Use(lambda schema: sources.Fault.from_corners(schema["corners"])),
+    )
+)
+
+
+SOURCE_SCHEMA = Schema(
+    {"source_geometries": {str: Or(POINT_SCHEMA, PLANE_SCHEMA, FAULT_SCHEMA)}}
+)
+
+SRF_SCHEMA = Schema(
+    {
+        Literal(
+            "genslip_dt",
+            description="The timestep for genslip (used to specify the resolution for the `TINIT` values)",
+        ): And(float, is_positive),
+        Literal("genslip_seed", description="The random seed passed to genslip"): And(
+            int, is_non_negative
+        ),
+        Literal("genslip_version", description="The version of genslip to use"): Or(
+            "5.4.2"
+        ),
+        Literal(
+            "srfgen_seed",
+            description="A second random seed for genslip (TODO: how does genslip use this value?)",
+        ): And(int, is_non_negative),
+        Literal("resolution", description="Subdivision resolution."): And(
+            float, is_positive
+        ),
+    }
+)
+
+DOMAIN_SCHEMA = Schema(
+    {
+        Literal("resolution", description="The simulation resolution (in km)"): And(
+            float, is_positive
+        ),
+        Literal("domain", description="The corners of the simulation domain."): And(
+            Use(corners_to_array), Use(BoundingBox.from_wgs84_coordinates)
+        ),
+        Literal("depth", description="The depth of the model (in km)"): And(
+            float, is_positive
+        ),
+        Literal(
+            "duration", description="The duration of the simulation (in seconds)"
+        ): And(float, is_positive),
+        Literal("dt", "The resolution of the domain in time (in seconds)."): And(
+            float, is_positive
+        ),
+    }
+)
+
+RUPTURE_PROPAGATION_SCHEMA = Schema(
+    {
+        Literal(
+            "hypocentre",
+            description="The hypocentre coordinates (or initial rupture point if not the initial fault)",
+        ): FAULT_LOCAL_COORDINATES_SCHEMA,
+        Literal(
+            "magnitudes",
+            description="The total moment magnitude for the rupture on this fault",
+        ): {str: And(float, is_plausible_magnitude)},
+        Literal("jump_points", description="The jump points for the rupture"): Or(
+            {
+                str: And(
+                    {
+                        "from_point": FAULT_LOCAL_COORDINATES_SCHEMA,
+                        "to_point": FAULT_LOCAL_COORDINATES_SCHEMA,
+                    },
+                    Use(lambda pts: rupture_propagation.JumpPair(**pts)),
+                )
+            },
+            {},
+        ),
+        Literal("rakes", description="The fault rakes"): {
+            str: And(float, is_valid_degrees)
+        },
+        Literal("rupture_causality_tree", description="The fault propagation tree"): {
+            str: Or(str, None)
+        },
+    }
+)
+
+VELOCITY_MODEL_SCHEMA = Schema(
+    {
+        Literal(
+            "min_vs",
+            description="The minimum velocity (km/s) produced in the velocity model.",
+        ): And(float, is_positive),
+        Literal("version", "Velocity model version"): "2.06",
+        Literal("topo_type", "Velocity model topology type"): str,
+        Literal("dt", "Velocity model timestep resolution"): And(float, is_positive),
+        Literal("ds_multiplier", "Velocity model ds multiplier"): And(
+            float, is_positive
+        ),
+        Literal("resolution", "Velocity model spatial resolution"): And(
+            float, is_positive
+        ),
+        Literal("vs30", "VS30 value"): And(float, is_positive),
+        Literal("s_wave_velocity", "S-wave velocity"): And(float, is_positive),
+        Literal('pgv_interpolants', 'PGV interpolants to estimate domain size'): And([[And(float, is_positive)]], Use(np.array))
+    }
+)
+
+REALISATION_METADATA_SCHEMA = Schema(
+    {
+        Literal("name", description="The name of the realisation"): str,
+        Literal("version", description="The version of the realisation format"): Or(
+            "1"
+        ),
+        Optional(
+            Literal(
+                "tag",
+                description="Metadata tag for the realisation used to specify the origin or category of the realisation (e.g. NSHM, GCMT or custom).",
+            )
+        ): Or(str, None),
+        Literal(
+            "defaults_version", description="Simulation default parameters version."
+        ): And(str, Use(DefaultsVersion)),
+    }
+)
+
+HF_CONFIG_SCHEMA = Schema(
+    {
+        Literal("nbu", description="Unknown!"): int,
+        Literal("ift", description="Unknown!"): int,
+        Literal("flo", description="Unknown!"): float,
+        Literal("fhi", description="Unknown!"): float,
+        Literal("nl_skip", description="Skip empty lines in input?"): int,
+        Literal("vp_sig", description="Unknown!"): float,
+        Literal("vsh_sig", description="Unknown!"): float,
+        Literal("rho_sig", description="Unknown!"): float,
+        Literal("qs_sig", description="Unknown!"): float,
+        Literal("ic_flag", description="Unknown!"): bool,
+        Literal("velocity_name", description="Unknown!"): str,
+        Literal("dt", description="Time resolution for HF simulation"): And(
+            float, is_positive
+        ),
+        Literal("t_sec", description="High frequency output start time."): And(
+            float, is_non_negative
+        ),
+        Literal("sdrop", description="Stress drop average (bars)"): float,
+        Literal("rayset", description="ray types 1: direct, 2: moho"): [Or(1, 2)],
+        Literal(
+            "no_siteamp", description="Disable BJ97 site amplification factors"
+        ): bool,
+        Literal("fmax", description="Max simulation frequency"): And(
+            float, is_positive
+        ),
+        Literal("kappa", description="Unknown!"): float,
+        Literal("qfexp", description="Q frequency exponent"): float,
+        Literal("rvfac", description="Rupture velocity factor (rupture : Vs)"): And(
+            float, is_non_negative
+        ),
+        Literal("rvfac_shal", description="rvfac shallow fault multiplier"): float,
+        Literal("rvfac_deep", description="rvfac deep fault multiplier"): float,
+        Literal("czero", description="C0 coefficient"): float,
+        Literal("calpha", description="Ca coefficient"): float,
+        Literal("mom", description="Seimic moment (or null, to infer value)"): Or(
+            float, None
+        ),
+        Literal("rupv", description="Rupture velocity (or binary default)"): Or(
+            float, None
+        ),
+        Literal("site_specific", description="Enable site-specific calculation"): bool,
+        Literal("vs_moho", description="vs of moho layer"): float,
+        Literal("fa_sig1", "Fourier amplitude uncertainty (1)"): float,
+        Literal("fa_sig2", description="Fourier amplitude uncertainty (2)"): float,
+        Literal("rv_sig1", description="Rupture velocity uncertainty"): And(
+            float, is_non_negative
+        ),
+        Literal(
+            "path_dur",
+            description="path duration model. 0: GP2010, 1: WUS modification trail/errol, 2: ENA modificiation trial/error"
+            ", 11: WUS formutian of BT2014, 12: ENA formulation of BT2015. Models 11 and 12 overpredict for multiple rays.",
+        ): Or(0, 1, 2, 11, 12),
+        Literal("dpath_pert", description="Log of path duration multiplier"): float,
+        Literal(
+            "stress_parameter_adjustment_tect_type",
+            description="Adjustment option 0 = off, 1 = active tectonic, 2 = stable continent",
+        ): Or(0, 1, 2),
+        Literal(
+            "stress_parameter_adjustment_target_magnitude",
+            description="Target magnitude (or inferred if null)",
+        ): Or(float, None),
+        Literal(
+            "stress_parameter_adjustment_fault_area", "Fault area (or inferred if null)"
+        ): Or(float, None),
+        Literal("seed", description="HF seed"): int,
+        Literal("stoch_dx", description="Stoch file dx"): And(float, is_positive),
+        Literal("stoch_dy", description="Stoch file dy"): And(float, is_positive),
+    }
+)
+
+EMOD3D_PARAMETERS_SCHEMA = Schema(
+    {
+        "all_in_one": int,
+        "bfilt": int,
+        "bforce": int,
+        "dampwidth": int,
+        "dblcpl": int,
+        "dmodfile": str,
+        "dtts": int,
+        "dump_itinc": int,
+        "dxout": int,
+        "dxts": int,
+        "dyout": int,
+        "dyts": int,
+        "dzout": int,
+        "dzts": int,
+        "elas_only": int,
+        "enable_output_dump": int,
+        "enable_restart": int,
+        "ffault": int,
+        "fhi": float,
+        "fmax": float,
+        "fmin": float,
+        "freesurf": int,
+        "geoproj": int,
+        "intmem": int,
+        "ix_ts": int,
+        "ix_ys": int,
+        "ix_zs": int,
+        "iy_ts": int,
+        "iy_xs": int,
+        "iy_zs": int,
+        "iz_ts": int,
+        "iz_xs": int,
+        "iz_ys": int,
+        "lonlat_out": int,
+        "maxmem": int,
+        "model_style": int,
+        "nseis": int,
+        "order": int,
+        "pmodfile": str,
+        "pointmt": int,
+        "qbndmax": float,
+        "qpfrac": float,
+        "qpqs_factor": float,
+        "qsfrac": float,
+        "read_restart": int,
+        "report": int,
+        "restart_itinc": int,
+        "scale": int,
+        "smodfile": str,
+        "span": int,
+        "stype": str,
+        "swap_bytes": int,
+        "ts_inc": int,
+        "ts_start": int,
+        "ts_total": int,
+        "ts_xy": int,
+        "ts_xz": int,
+        "ts_yz": int,
+        "tzero": float,
+        "vmodel_swapb": int,
+        "xseis": int,
+        "yseis": int,
+        "zseis": int,
+        "pertbfile": str,
+    }
+)
+
+BROADBAND_PARAMETERS_SCHEMA = Schema(
+    {
+        Literal("flo", description="low/high frequency cutoff"): And(
+            float, is_non_negative
+        ),
+        Literal("dt", description="simulation time resolution"): And(
+            float, is_positive
+        ),
+        Literal("fmidbot", description="fmidbot for site amplification"): And(
+            float, is_non_negative
+        ),
+        Literal("fmin", description="fmin for site amplification"): And(
+            float, is_non_negative
+        ),
+        "site_amp_version": str,
+    }
+)
+
+
+class IntensityMeasure(StrEnum):
+    """Intensity Measures for IM Calculation."""
+
+    PGA = "PGA"
+    PGV = "PGV"
+    CAV = "CAV"
+    AI = "AI"
+    DS575 = "Ds575"
+    DS595 = "Ds595"
+    MMI = "MMI"
+    PSA = "pSA"
+    SED = "SED"
+    FAS = "FAS"
+    SDI = "SDI"
+
+
+class Component(StrEnum):
+    """Component values for IM calculation."""
+
+    C090 = "090"
+    C000 = "000"
+    VER = "ver"
+    H1 = "H1"
+    H2 = "H2"
+    GEOM = "geom"
+    ROTD50 = "rotd50"
+    ROTD100 = "rotd100"
+    ROTD100_50 = "rotd100_50"
+    NORM = "norm"
+    EAS = "EAS"
+
+
+class Units(StrEnum):
+    """Units for IM Calculation."""
+
+    g = "g"
+    cms2 = "cm/s^2"
+
+
+INTENSITY_MEASURE_CALCUATION_PARAMETERS = Schema(
+    {
+        Literal("ims", description="Intensity measures to calculate"): [
+            And(str, Use(IntensityMeasure))
+        ],
+        Literal(
+            "components", description="Components to calculate intensity measures in"
+        ): [And(str, Use(Component))],
+        Literal("valid_periods", description="Valid periods to calculate for"): And(
+            [And(float, is_positive)], Use(np.array)
+        ),
+        Literal("fas_frequencies", description="Fourier spectrum frequencies"): And(
+            [And(float, is_positive)], Use(np.array)
+        ),
+        Literal("units", description="Units to calculate intensity measures in"): And(
+            str, Use(Units)
+        ),
+    }
+)

--- a/workflow/schemas.py
+++ b/workflow/schemas.py
@@ -475,9 +475,9 @@ EMOD3D_PARAMETERS_SCHEMA = Schema(
             "all_in_one",
             description="Handles the option to output all-in-one seismograms.",
         ): bool,
-        Literal(
-            "bfilt", description="Indicates whether bandpass filtering is applied."
-        ): bool,
+        Literal("bfilt", description="Bandpass filtering order."): And(
+            int, is_non_negative
+        ),
         Literal("bforce", description="If true, applies body force source."): bool,
         Literal("dampwidth", description="Width of damping region."): int,
         Literal("dblcpl", description="Specifies double couple source"): bool,
@@ -495,8 +495,10 @@ EMOD3D_PARAMETERS_SCHEMA = Schema(
         Literal("elas_only", description="If true, perform elastic calculations"): bool,
         "enable_output_dump": bool,
         Literal("enable_restart", description="Enable checkpoints"): bool,
-        Literal("ffault", description="If true, source is a finite fault."): bool,
-        Literal("fhi", description="High-frequency cutoff."): And(float, is_positive),
+        Literal("ffault", description="Finite fault model source."): int,
+        Literal("fhi", description="High-frequency cutoff."): And(
+            float, is_non_negative
+        ),
         Literal("fmax", description="Maximum simulation frequency"): And(
             float, is_positive
         ),

--- a/workflow/schemas.py
+++ b/workflow/schemas.py
@@ -10,9 +10,8 @@ from enum import StrEnum
 
 import numpy as np
 from schema import And, Literal, Optional, Or, Schema, Use
-from velocity_modelling.bounding_box import BoundingBox
-
 from source_modelling import rupture_propagation, sources
+from velocity_modelling.bounding_box import BoundingBox
 from workflow.defaults import DefaultsVersion
 
 # NOTE: These functions seem silly and short, however there is a good
@@ -374,7 +373,9 @@ VELOCITY_MODEL_SCHEMA = Schema(
         ),
         Literal("vs30", "VS30 value"): And(float, is_positive),
         Literal("s_wave_velocity", "S-wave velocity"): And(float, is_positive),
-        Literal('pgv_interpolants', 'PGV interpolants to estimate domain size'): And([[And(float, is_positive)]], Use(np.array))
+        Literal("pgv_interpolants", "PGV interpolants to estimate domain size"): And(
+            [[And(float, is_positive)]], Use(np.array)
+        ),
     }
 )
 
@@ -470,30 +471,47 @@ HF_CONFIG_SCHEMA = Schema(
 
 EMOD3D_PARAMETERS_SCHEMA = Schema(
     {
-        "all_in_one": int,
-        "bfilt": int,
-        "bforce": int,
-        "dampwidth": int,
-        "dblcpl": int,
-        "dmodfile": str,
-        "dtts": int,
-        "dump_itinc": int,
+        Literal(
+            "all_in_one",
+            description="Handles the option to output all-in-one seismograms.",
+        ): bool,
+        Literal(
+            "bfilt", description="Indicates whether bandpass filtering is applied."
+        ): bool,
+        Literal("bforce", description="If true, applies body force source."): bool,
+        Literal("dampwidth", description="Width of damping region."): int,
+        Literal("dblcpl", description="Specifies double couple source"): bool,
+        Literal("dmodfile", description="Name of density velocity model file"): str,
+        Literal("dtts", description="dt per timeslice"): And(int, is_positive),
+        Literal("dump_itinc", description="Increment to dump output"): And(
+            int, is_positive
+        ),
         "dxout": int,
-        "dxts": int,
+        Literal("dxts", description="dx per timeslice"): And(int, is_positive),
         "dyout": int,
-        "dyts": int,
+        Literal("dyts", description="dy per timeslice"): And(int, is_positive),
         "dzout": int,
-        "dzts": int,
-        "elas_only": int,
-        "enable_output_dump": int,
-        "enable_restart": int,
-        "ffault": int,
-        "fhi": float,
-        "fmax": float,
-        "fmin": float,
-        "freesurf": int,
-        "geoproj": int,
-        "intmem": int,
+        Literal("dzts", description="dz per timeslice"): And(int, is_positive),
+        Literal("elas_only", description="If true, perform elastic calculations"): bool,
+        "enable_output_dump": bool,
+        Literal("enable_restart", description="Enable checkpoints"): bool,
+        Literal("ffault", description="If true, source is a finite fault."): bool,
+        Literal("fhi", description="High-frequency cutoff."): And(float, is_positive),
+        Literal("fmax", description="Maximum simulation frequency"): And(
+            float, is_positive
+        ),
+        Literal("fmin", description="Minimum simulation frequency"): And(
+            float, is_positive
+        ),
+        Literal(
+            "freesurf",
+            description="Boundary condition: false for absorbing, true for free surface.",
+        ): bool,
+        Literal(
+            "geoproj",
+            description="The geographic projection to use. False for spherical projection with local kmplat and kmplon, true for standard spherical projection",
+        ): bool,
+        Literal("intmem", description="Internal memory flag for model storage"): bool,
         "ix_ts": int,
         "ix_ys": int,
         "ix_zs": int,
@@ -503,37 +521,57 @@ EMOD3D_PARAMETERS_SCHEMA = Schema(
         "iz_ts": int,
         "iz_xs": int,
         "iz_ys": int,
-        "lonlat_out": int,
-        "maxmem": int,
-        "model_style": int,
+        Literal(
+            "lonlat_out", description="Output coordinates in longitude and latitude."
+        ): bool,
+        Literal("maxmem", description="Maximum memory usage in Mb"): And(
+            int, is_positive
+        ),
+        Literal("model_style", description="Model type for simulation."): Or(
+            0, 1, 2, 3
+        ),
         "nseis": int,
-        "order": int,
-        "pmodfile": str,
-        "pointmt": int,
-        "qbndmax": float,
-        "qpfrac": float,
-        "qpqs_factor": float,
-        "qsfrac": float,
-        "read_restart": int,
-        "report": int,
-        "restart_itinc": int,
+        Literal("order", description="Spatial differencing order."): And(
+            int, is_positive
+        ),
+        Literal("pmodfile", description="Name of the Vp file."): str,
+        Literal(
+            "pointmt", description="If true, use a point moment tensor source flag"
+        ): bool,
+        Literal("qbndmax", descrption="Maximum boundary quality factor"): float,
+        Literal("qpfrac", description="Multiplier from Vp, to Qp"): float,
+        Literal("qpqs_factor", description="Ratio between Qp and Qs"): float,
+        Literal("qsfrac", description="Ratio between Vs to Qs."): float,
+        Literal("read_restart", description="If true read from checkpoint files"): bool,
+        Literal("report", description="Reporting increment."): And(int, is_positive),
+        Literal("restart_itinc", description="Checkpoint iteration increment"): And(
+            int, is_positive
+        ),
         "scale": int,
-        "smodfile": str,
-        "span": int,
-        "stype": str,
-        "swap_bytes": int,
-        "ts_inc": int,
-        "ts_start": int,
-        "ts_total": int,
-        "ts_xy": int,
-        "ts_xz": int,
-        "ts_yz": int,
-        "tzero": float,
-        "vmodel_swapb": int,
+        Literal("smodfile", description="Path to the vs file."): str,
+        Literal("span", description="Number of timesteps per I/O operation."): And(
+            int, is_positive
+        ),
+        Literal("stype", description="Source time function type."): str,
+        Literal("swap_bytes", description="If true, swap byte output order."): bool,
+        Literal("ts_inc", description="Time slice increment."): And(int, is_positive),
+        Literal("ts_start", description="Start time for time slices."): And(
+            int, is_non_negative
+        ),
+        Literal("ts_total", description="Total number of time slices."): And(
+            int, is_positive
+        ),
+        Literal("ts_xy", description="Enable xy time slices"): bool,
+        Literal("ts_xz", description="Enable xz time slices"): bool,
+        Literal("ts_yz", description="Enable yz time slices"): bool,
+        Literal("tzero", description="Start time offset."): float,
+        Literal(
+            "vmodel_swapb", description="If true, swap velocity model byte order"
+        ): bool,
         "xseis": int,
         "yseis": int,
         "zseis": int,
-        "pertbfile": str,
+        Literal("pertbfile", description="Path to perturbation file."): str,
     }
 )
 

--- a/workflow/schemas.py
+++ b/workflow/schemas.py
@@ -10,8 +10,9 @@ from enum import StrEnum
 
 import numpy as np
 from schema import And, Literal, Optional, Or, Schema, Use
-from source_modelling import rupture_propagation, sources
 from velocity_modelling.bounding_box import BoundingBox
+
+from source_modelling import rupture_propagation, sources
 from workflow.defaults import DefaultsVersion
 
 # NOTE: These functions seem silly and short, however there is a good


### PR DESCRIPTION
# Realisations

The following PR updates the realisations for the new workflow. The API for realisations has changed since the last pull request for realisations. The new workflow realisations aim to be a well-documented, modular, and self-contained method for simulation configuration. The idea is that the scientific defaults version, container version, and realisation file should completely determine the simulation output up to hardware-level floating point mathematics differences.

> [!NOTE]
> Only the `realisations.py`, `test_realisation.py`, and `schemas.py` files need to be reviewed. The defaults are otherwise as they are in #5 , and are there to allow the tests to pass.

## Using the Realisations Module

Reading and writing realisations involves using one of the classes to read and write realisation configurations. To retrieve the domain parameters of the realisation for example you would write something like

``` python
# For a realisation with contents
#  {
#    "domain": {
#        "resolution": 0.2,
#        "domain": [
#                  { "latitude": -44.354733203836375, "longitude": 168.32522375230945 },
#                  { "latitude": -45.860251409924196, "longitude": 170.71966358185924 },
#                  { "latitude": -42.084729432307505, "longitude": 174.9917352035785 },
#                  { "latitude": -40.66798264759381, "longitude": 172.63541186873076 }
#        ],
#        "depth": 50.0,
#        "duration": 60.0,
#        "dt": 0.01
#    }
# }
#
#
#
>>> from workflow.realisations import DomainParameters
>>> domain_parameters = DomainParameters.read_from_realisation('realisation.json')
DomainParameters(
        resolution=0.2,
        domain=BoundingBox(...)
        depth=50.0,
        duration=60.0,
        dt=0.01
)
>>> domain_parameters.write_to_realisation('realisation.json')
```

Realisations can load default values for some configuration sections using `read_from_realisation_or_defaults`

``` python
# For a realisation with contents
#  {
#    "domain": {
#        "resolution": 0.2,
#        "domain": [
#                  { "latitude": -44.354733203836375, "longitude": 168.32522375230945 },
#                  { "latitude": -45.860251409924196, "longitude": 170.71966358185924 },
#                  { "latitude": -42.084729432307505, "longitude": 174.9917352035785 },
#                  { "latitude": -40.66798264759381, "longitude": 172.63541186873076 }
#        ],
#        "depth": 50.0,
#        "duration": 60.0,
#        "dt": 0.01
#    }
# }
#
# NOTE: There is no velocity model parameters in this realisation
#
>>> from workflow.realisations import VelocityModelParameters
>>> from workflow.defaults import DefaultsVersion
>>> VelocityModelParameters.read_from_realisation_or_defaults('realisation.json', DefaultsVersion.v24_2_2_2)
VelocityModelParameters(
    min_vs=0.5,
    version='2.06',
    topo_type='SQUASHED_TAPERED',
    dt=0.01,
    ds_multiplier=1.2,
    resolution=0.2,
    vs30=500.0,
    s_wave_velocity=3500.0,
    pgv_interpolants=array([
      [3.5, 0.015],
      [4.1, 0.0375],
      [4.7, 0.075],
      [5.2, 0.15],
      [5.5, 0.25],
      [5.8, 0.4],
      [6.2, 0.7],
      [6.5, 1.0],
      [6.8, 1.35],
      [7.0, 1.65],
      [7.4, 2.1],
      [7.7, 2.5],
      [8.0, 3.0]
    ])
)
# These values were read from the 24.2.2.2 defaults yaml file.
```

Realisations have rudimentary value checking applied in the `schemas` module, which also defines the schema for each realisation section. For instance, here is the schema for the velocity model parameters.

``` python
VELOCITY_MODEL_SCHEMA = Schema(
    {
        Literal(
            "min_vs",
            description="The minimum velocity (km/s) produced in the velocity model.",
        ): And(float, is_positive),
        Literal("version", "Velocity model version"): "2.06",
        Literal("topo_type", "Velocity model topology type"): str,
        Literal("dt", "Velocity model timestep resolution"): And(float, is_positive),
        Literal("ds_multiplier", "Velocity model ds multiplier"): And(
            float, is_positive
        ),
        Literal("resolution", "Velocity model spatial resolution"): And(
            float, is_positive
        ),
        Literal("vs30", "VS30 value"): And(float, is_positive),
        Literal("s_wave_velocity", "S-wave velocity"): And(float, is_positive),
        Literal('pgv_interpolants', 'PGV interpolants to estimate domain size'): And([[And(float, is_positive)]], Use(np.array))
    }
)
```

Adding a new realisation configuration is done by inheriting from the `RealisationConfiguration` class and then defining the key in the json file, the schema to validate against, and the values to store. Overriding the `to_dict` method lets you change the JSON serialisation behaviour. Here is an example of that for the velocity model parameters.

``` python
@dataclasses.dataclass
class VelocityModelParameters(RealisationConfiguration):
    """Parameters defining the velocity model."""

    _config_key: ClassVar[str] = "velocity_model"
    _schema: ClassVar[Schema] = schemas.VELOCITY_MODEL_SCHEMA

    min_vs: float
    """The minimum velocity in the velocity model."""
    version: str
    """The velocity model version."""
    topo_type: str
    """The topology type of the velocity model."""
    dt: float
    """The velocity model time resolution."""
    ds_multiplier: float
    """The ds multiplier used to adjust simulation duration."""
    resolution: float
    """The resolution of the velocity model (in kilometres)."""
    vs30: float
    """The reference vs30 value for duration estimation."""
    s_wave_velocity: float
    """The s-wave velocity."""
    pgv_interpolants: npt.NDArray[np.float32]
    """PGV interpolation nodes between rupture magnitude and PGV target values."""

    def to_dict(self) -> dict:
        """
        Convert the object to a dictionary representation.

        Returns
        -------
        dict
            Dictionary representation of the object.
        """
        _dict = dataclasses.asdict(self)
        _dict["pgv_interpolants"] = _dict["pgv_interpolants"].tolist()
        return _dict
```

Some values for the realisation configuration are computed simply using values stored in the file. These values are now computed using Python properties rather than being stored in the realisation. For example the `nx`, `ny`, and `nz` values for the domain parameters are properties computed from the domain.

``` python
@dataclasses.dataclass
class DomainParameters(RealisationConfiguration):
    """Parameters defining the spatial and temporal domain for simulation."""

    _config_key: ClassVar[str] = "domain"
    _schema: ClassVar[Schema] = schemas.DOMAIN_SCHEMA

    resolution: float
    """The simulation resoultion in kilometres."""
    domain: BoundingBox
    """The bounding box for the domain."""
    depth: float
    """The depth of the domain (in metres)."""
    duration: float
    """The simulation duration (in seconds)."""
    dt: float
    """The resolution of the domain in time (in seconds)."""

    @property
    def nx(self) -> int:
        """int: The number of x coordinate positions in the discretised domain."""
        return int(np.round(self.domain.extent_x / self.resolution))

    @property
    def ny(self) -> int:
        """int: The number of y coordinate positions in the discretised domain."""
        return int(np.round(self.domain.extent_y / self.resolution))

    @property
    def nz(self) -> int:
        """int: The number of z coordinate positions in the discretised domain."""
        return int(np.round(self.depth / self.resolution))

    def to_dict(self) -> dict:
        """
        Convert the object to a dictionary representation.

        Returns
        -------
        dict
            Dictionary representation of the object.
        """
        param_dict = dataclasses.asdict(self)
        param_dict["domain"] = to_name_coordinate_dictionary(
            self.domain.corners,
        )
        return param_dict
```

Having these as properties means it is impossible to have the `nx`, `ny` and `nz` values be inconsistent with the domain.


## Testing

Inline with the discussions on testing earlier in the year, there is extensive testing for every line of the realisation and schema module. The tests are located in the `test_realisation.py` file. The tests ensure:

1. Every realisation section is read and written in the correct way from the JSON file.
2. Every defined defaults version is readable.