### PR TITLE
Xarray, Units and Fixes for im-calc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ nshmdb @ git+https://github.com/ucgmsim/NSHM2022DB.git
 numexpr
 numpy<2
 pandas
-pint-xarray
 printree
 pyarrow
 pygmt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,9 @@ empirical @ git+https://github.com/ucgmsim/Empirical_Engine.git
 fastparquet
 geopandas
 h5py
-h5netcdf
 jinja2
 networkx
 nshmdb @ git+https://github.com/ucgmsim/NSHM2022DB.git
-numba
 numexpr
 numpy<2
 pandas
@@ -14,7 +12,6 @@ printree
 pygmt
 pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper.git
 pyarrow
-pykooh
 pytest
 pyvis
 pyvista
@@ -29,5 +26,5 @@ tables
 tqdm
 typer
 im_calculation @ git+https://github.com/ucgmsim/IM_calculation.git
-xarray
+xarray[io]
 velocity_modelling @ git+https://github.com/ucgmsim/velocity_modelling.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,16 +2,18 @@ empirical @ git+https://github.com/ucgmsim/Empirical_Engine.git
 fastparquet
 geopandas
 h5py
+im_calculation @ git+https://github.com/ucgmsim/IM_calculation.git
 jinja2
 networkx
 nshmdb @ git+https://github.com/ucgmsim/NSHM2022DB.git
 numexpr
 numpy<2
 pandas
+pint-xarray
 printree
+pyarrow
 pygmt
 pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper.git
-pyarrow
 pytest
 pyvis
 pyvista
@@ -25,6 +27,5 @@ source_modelling @ git+https://github.com/ucgmsim/source_modelling.git
 tables
 tqdm
 typer
-im_calculation @ git+https://github.com/ucgmsim/IM_calculation.git
-xarray[io]
 velocity_modelling @ git+https://github.com/ucgmsim/velocity_modelling.git
+xarray[io]

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -35,10 +35,10 @@ import h5py
 import numexpr as ne
 import numpy as np
 import pandas as pd
+import pint_xarray  # noqa: F401
 import tqdm
 import typer
 import xarray as xr
-import pint_xarray
 
 from IM import ims, units
 from IM.im_calculation import IM
@@ -218,6 +218,7 @@ def calculate_instensity_measures(
     # Add each column of the DataFrame as a coordinate
     for column in station_metadata.columns:
         dataset = dataset.assign_coords({column: ("station", station_metadata[column])})
+
     dataset = dataset.pint.quantify(columns)
 
     for im_name in (pbar := tqdm.tqdm(intensity_measures)):

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -35,12 +35,11 @@ import h5py
 import numexpr as ne
 import numpy as np
 import pandas as pd
-import pint_xarray  # noqa: F401
 import tqdm
 import typer
 import xarray as xr
 
-from IM import ims, units
+from IM import ims, im_reader
 from IM.im_calculation import IM
 from qcore import coordinates
 from workflow import utils
@@ -204,33 +203,9 @@ def calculate_instensity_measures(
         / 1000
     )
 
-    coordinate_metadata = {
-        "station": {"description": "Station identifiers", "units": None},
-        "component": {"description": "Component of motion", "units": None},
-        "period": {"description": "Oscillation period", "units": "s"},
-        "vs30": {
-            "description": "Average shear-wave velocity to 30m depth",
-            "units": "m/s",
-        },
-        "epi": {"description": "Epicentral distance", "units": "km"},
-        "hyp": {"description": "Hypocentral distance", "units": "km"},
-        "rrup": {"description": "Rupture distance", "units": "km"},
-        "rjb": {"description": "Joyner-Boore distance", "units": "km"},
-        "latitude": {"description": "Station latitude", "units": "degrees"},
-        "longitude": {"description": "Station longitude", "units": "degrees"},
-        "frequency": {"description": "Frequency of motion", "units": "Hz"},
-    }
-    ims_metadata = {
-        IM.PGA: "Peak ground acceleration",
-        IM.PGV: "Peak ground velocity",
-        IM.CAV: "Cumulative absolute velocity",
-        IM.AI: "Arias intensity",
-        IM.Ds575: "Significant duration (5-75%)",
-        IM.Ds595: "Significant duration (5-95%)",
-        IM.pSA: "Pseudo-spectral acceleration",
-        IM.FAS: "Fourier amplitude spectrum",
-    }
-    station_metadata = stations[list(set(coordinate_metadata) & set(stations.columns))]
+    station_metadata = stations[
+        list(set(im_reader.IM_METADATA) & set(stations.columns))
+    ]
 
     dataset = xr.Dataset(coords={"station": station_metadata.index})
 
@@ -249,11 +224,5 @@ def calculate_instensity_measures(
         elif isinstance(result, xr.DataArray):
             result = result.assign_coords(station=stations.index.values)
         dataset[im_name] = result
-        dataset[im_name].attrs["description"] = ims_metadata[im_name]
 
-    dataset = dataset.pint.quantify(units.IM_UNITS)
-
-    for name, description in coordinate_metadata.items():
-        dataset.coords[name].attrs.update(coordinate_metadata[name])
-
-    dataset.pint.dequantify().to_netcdf(output_path, mode="w", engine="h5netcdf")
+    im_reader.write_intensity_measures(dataset, output_path)

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -38,14 +38,18 @@ import pandas as pd
 import tqdm
 import typer
 import xarray as xr
+import pint_xarray
 
-from IM import ims
+from IM import ims, units
 from IM.im_calculation import IM
+from qcore import coordinates
 from workflow import utils
 from workflow.realisations import (
     BroadbandParameters,
     IntensityMeasureCalculationParameters,
     RealisationMetadata,
+    RupturePropagationConfig,
+    SourceConfig,
 )
 
 app = typer.Typer()
@@ -102,11 +106,14 @@ def calculate_instensity_measures(
             realisation_ffp, metadata.defaults_version
         )
     )
+    source_geometries = SourceConfig.read_from_realisation(realisation_ffp)
+    rup_prop_config = RupturePropagationConfig.read_from_realisation(realisation_ffp)
 
     with h5py.File(broadband_simulation_ffp, mode="r") as broadband_file:
         waveforms = np.array(broadband_file["waveforms"]).astype(np.float32)
 
     stations = pd.read_hdf(broadband_simulation_ffp, key="stations")
+
     if not simulated_stations:
         stations = stations.filter(regex=r"^\w{4}$", axis=0)
         waveforms = waveforms[stations["waveform_index"]]
@@ -148,16 +155,82 @@ def calculate_instensity_measures(
             cores=utils.get_available_cores(),
         ),
     }
+    stations["rrup"] = (
+        np.array(
+            [
+                min(
+                    source.rrup_distance(np.append(station, 0))
+                    for source in source_geometries.source_geometries.values()
+                )
+                for station in stations[["latitude", "longitude"]].values
+            ]
+        )
+        / 1000
+    )
+    stations["rjb"] = (
+        np.array(
+            [
+                min(
+                    source.rjb_distance(np.append(station, 0))
+                    for source in source_geometries.source_geometries.values()
+                )
+                for station in stations[["latitude", "longitude"]].values
+            ]
+        )
+        / 1000
+    )
+    hypocentre = source_geometries.source_geometries[
+        rup_prop_config.initial_fault
+    ].fault_coordinates_to_wgs_depth_coordinates(rup_prop_config.hypocentre)
+    stations["hyp"] = (
+        coordinates.distance_between_wgs_depth_coordinates(
+            np.hstack(
+                (
+                    stations[["latitude", "longitude"]].values,
+                    np.zeros((len(stations), 1)),
+                )
+            ),
+            hypocentre,
+        )
+        / 1000
+    )
+    stations["epi"] = (
+        coordinates.distance_between_wgs_depth_coordinates(
+            stations[["latitude", "longitude"]].values,
+            hypocentre[:2],
+        )
+        / 1000
+    )
+    columns = {
+        "vs30": "km/s",
+        "epi": "km",
+        "hyp": "km",
+        "rrup": "km",
+        "rjb": "km",
+        "latitude": None,
+        "longitude": None,
+    }
+
+    station_metadata = stations[list(columns)]
+
+    dataset = xr.Dataset(coords={"station": station_metadata.index})
+
+    # Add each column of the DataFrame as a coordinate
+    for column in station_metadata.columns:
+        dataset = dataset.assign_coords({column: ("station", station_metadata[column])})
+    dataset = dataset.pint.quantify(columns)
+
     for im_name in (pbar := tqdm.tqdm(intensity_measures)):
         pbar.set_description(im_name)
         im_fn = im_function_map[im_name]
         result = im_fn(waveforms)
+
         if isinstance(result, pd.DataFrame):
             result["station"] = stations.index.values
-            result = result.set_index("station")
-            result.to_hdf(output_path, key=im_name, mode="a")
+            result = result.set_index("station").to_xarray().to_array(dim="component")
         elif isinstance(result, xr.DataArray):
             result = result.assign_coords(station=stations.index.values)
-            # NetCDF is a file format that is compatible with HDF5. For
-            # legacy reasons, xarray uses `to_netcdf` instead of `to_hdf5`.
-            result.to_netcdf(output_path, mode="a", group=im_name, engine="h5netcdf")
+        dataset[im_name] = result
+
+    dataset = dataset.pint.quantify(units.IM_UNITS)
+    dataset.pint.dequantify().to_netcdf(output_path, mode="w", engine="h5netcdf")

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -39,7 +39,7 @@ import tqdm
 import typer
 import xarray as xr
 
-from IM import ims, im_reader
+from IM import im_reader, ims
 from IM.im_calculation import IM
 from qcore import coordinates
 from workflow import utils

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -114,23 +114,19 @@ def calculate_instensity_measures(
     intensity_measures = intensity_measure_parameters.ims
     nyquist_frequency = 1 / (2 * broadband_parameters.dt)
     im_function_map = {
-        IM.PGA: functools.partial(ims.peak_ground_velocity, dt=broadband_parameters.dt),
+        IM.PGA: ims.peak_ground_acceleration,
         IM.PGV: functools.partial(ims.peak_ground_velocity, dt=broadband_parameters.dt),
         IM.CAV: functools.partial(
             ims.cumulative_absolute_velocity, dt=broadband_parameters.dt
         ),
         IM.AI: functools.partial(ims.arias_intensity, dt=broadband_parameters.dt),
         IM.Ds575: functools.partial(
-            ims.significant_duration,
+            ims.ds575,
             dt=broadband_parameters.dt,
-            percent_low=5,
-            percent_high=75,
         ),
         IM.Ds595: functools.partial(
-            ims.significant_duration,
+            ims.ds595,
             dt=broadband_parameters.dt,
-            percent_low=5,
-            percent_high=75,
         ),
         IM.pSA: functools.partial(
             ims.pseudo_spectral_acceleration,
@@ -146,11 +142,14 @@ def calculate_instensity_measures(
         IM.FAS: functools.partial(
             ims.fourier_amplitude_spectra,
             dt=broadband_parameters.dt,
-            freqs=intensity_measure_parameters.fas_frequencies[intensity_measure_parameters.fas_frequencies <= nyquist_frequency],
+            freqs=intensity_measure_parameters.fas_frequencies[
+                intensity_measure_parameters.fas_frequencies <= nyquist_frequency
+            ],
             cores=utils.get_available_cores(),
         ),
     }
-    for im_name in tqdm.tqdm(intensity_measures):
+    for im_name in (pbar := tqdm.tqdm(intensity_measures)):
+        pbar.set_description(im_name)
         im_fn = im_function_map[im_name]
         result = im_fn(waveforms)
         if isinstance(result, pd.DataFrame):
@@ -161,4 +160,4 @@ def calculate_instensity_measures(
             result = result.assign_coords(station=stations.index.values)
             # NetCDF is a file format that is compatible with HDF5. For
             # legacy reasons, xarray uses `to_netcdf` instead of `to_hdf5`.
-            result.to_netcdf(output_path, mode="a", group=im_name)
+            result.to_netcdf(output_path, mode="a", group=im_name, engine="h5netcdf")

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -120,6 +120,7 @@ def calculate_instensity_measures(
 
     intensity_measures = intensity_measure_parameters.ims
     nyquist_frequency = 1 / (2 * broadband_parameters.dt)
+
     im_function_map = {
         IM.PGA: ims.peak_ground_acceleration,
         IM.PGV: functools.partial(ims.peak_ground_velocity, dt=broadband_parameters.dt),
@@ -155,6 +156,7 @@ def calculate_instensity_measures(
             cores=utils.get_available_cores(),
         ),
     }
+
     stations["rrup"] = (
         np.array(
             [
@@ -201,25 +203,40 @@ def calculate_instensity_measures(
         )
         / 1000
     )
-    columns = {
-        "vs30": "km/s",
-        "epi": "km",
-        "hyp": "km",
-        "rrup": "km",
-        "rjb": "km",
-        "latitude": None,
-        "longitude": None,
-    }
 
-    station_metadata = stations[list(columns)]
+    coordinate_metadata = {
+        "station": {"description": "Station identifiers", "units": None},
+        "component": {"description": "Component of motion", "units": None},
+        "period": {"description": "Oscillation period", "units": "s"},
+        "vs30": {
+            "description": "Average shear-wave velocity to 30m depth",
+            "units": "m/s",
+        },
+        "epi": {"description": "Epicentral distance", "units": "km"},
+        "hyp": {"description": "Hypocentral distance", "units": "km"},
+        "rrup": {"description": "Rupture distance", "units": "km"},
+        "rjb": {"description": "Joyner-Boore distance", "units": "km"},
+        "latitude": {"description": "Station latitude", "units": "degrees"},
+        "longitude": {"description": "Station longitude", "units": "degrees"},
+        "frequency": {"description": "Frequency of motion", "units": "Hz"},
+    }
+    ims_metadata = {
+        IM.PGA: "Peak ground acceleration",
+        IM.PGV: "Peak ground velocity",
+        IM.CAV: "Cumulative absolute velocity",
+        IM.AI: "Arias intensity",
+        IM.Ds575: "Significant duration (5-75%)",
+        IM.Ds595: "Significant duration (5-95%)",
+        IM.pSA: "Pseudo-spectral acceleration",
+        IM.FAS: "Fourier amplitude spectrum",
+    }
+    station_metadata = stations[list(set(coordinate_metadata) & set(stations.columns))]
 
     dataset = xr.Dataset(coords={"station": station_metadata.index})
 
     # Add each column of the DataFrame as a coordinate
     for column in station_metadata.columns:
         dataset = dataset.assign_coords({column: ("station", station_metadata[column])})
-
-    dataset = dataset.pint.quantify(columns)
 
     for im_name in (pbar := tqdm.tqdm(intensity_measures)):
         pbar.set_description(im_name)
@@ -232,6 +249,11 @@ def calculate_instensity_measures(
         elif isinstance(result, xr.DataArray):
             result = result.assign_coords(station=stations.index.values)
         dataset[im_name] = result
+        dataset[im_name].attrs["description"] = ims_metadata[im_name]
 
     dataset = dataset.pint.quantify(units.IM_UNITS)
+
+    for name, description in coordinate_metadata.items():
+        dataset.coords[name].attrs.update(coordinate_metadata[name])
+
     dataset.pint.dequantify().to_netcdf(output_path, mode="w", engine="h5netcdf")


### PR DESCRIPTION
Couple of fixes:

1. Erroneous reference to PGV when calculating PGA,
2. Add description of currently computed IM (I always intended to have this, but just forgot to include it).

The big change is using units and xarray datasets to save intensity measures. This obviates the need for the `im_reader` class, improves the sharability of intensity measure files, and makes it trivial to plot intensity measures for researchers.

When you load an IM calculation result now, you get an [xarray Dataset](https://docs.xarray.dev/en/latest/user-guide/data-structures.html#dataset). An xarray dataset is like a multi-dimensional pandas dataframe with some extra features.

```python
>>> import xarray as xr
>>> arr = xr.open_dataset('ims.h5', engine='h5netcdf')
<xarray.Dataset> Size: 1MB
Dimensions:    (component: 7, station: 217, period: 31, frequency: 90)
Coordinates:
  * station    (station) <U4 3kB '042A' '051B' '051D' ... 'WTSZ' 'WVZS' 'SM1F'
  * component  (component) <U7 196B '000' '090' 'ver' ... 'rotd50' 'rotd0'
  * period     (period) float32 124B 0.01 0.02 0.03 0.04 ... 5.0 6.0 7.5 10.0
    vs30       (station) int64 2kB ...
    epi        (station) float64 2kB ...
    hyp        (station) float64 2kB ...
    rrup       (station) float64 2kB ...
    rjb        (station) float64 2kB ...
    latitude   (station) float64 2kB ...
    longitude  (station) float64 2kB ...
  * frequency  (frequency) float64 720B 0.1 0.1072 0.115 ... 43.29 46.42 49.77
Data variables:
    PGA        (component, station) float32 6kB ...
    PGV        (component, station) float32 6kB ...
    CAV        (component, station) float32 6kB ...
    AI         (component, station) float64 12kB ...
    Ds575      (component, station) float64 12kB ...
    Ds595      (component, station) float64 12kB ...
    pSA        (component, station, period) float32 188kB ...
    FAS        (component, station, frequency) float64 1MB ...
```

Because xarray datasets are multidimensional, they can express things that would take a quite a few lines in pandas:

```python
# compare pSA (1s) with FAS (1hz) for all stations with rrup less than 100km and convert to a pandas dataframe.
>>> ds.sel(component='geom', period=1, frequency=1).where(ds.rrup < 100, drop=True)[['pSA', 'FAS']].to_dataframe()
              pSA       FAS component  period  vs30         epi         hyp       rrup        rjb  latitude  longitude  frequency
station                                                                                                                          
060B     0.071939  0.015987      geom     1.0   244  120.601675  120.866594  95.754042  95.331090 -42.81536  173.27094        1.0
112A     0.176456  0.057609      geom     1.0   275   55.162822   55.739631  52.009246  52.009246 -43.13427  171.76756        1.0
112B     0.176456  0.057609      geom     1.0   275   55.162822   55.739631  52.009246  52.009246 -43.13427  171.76756        1.0
274A     0.592700  0.119349      geom     1.0   213   33.815607   34.748594  23.951019  18.708888 -43.52171  172.58136        1.0
275A     0.439316  0.093010      geom     1.0   400   30.582665   31.611215  19.136407  13.674039 -43.49051  172.53615        1.0
...           ...       ...       ...     ...   ...         ...         ...        ...        ...       ...        ...        ...
SKTD     0.568959  0.123998      geom     1.0   500   16.466785   18.306407  15.198569   9.555717 -43.68436  172.19773        1.0
STLD     0.343568  0.110930      geom     1.0   500   28.609599   29.706542  10.932616  10.932616 -43.61310  171.82451        1.0
TLED     0.687009  0.138050      geom     1.0   500    7.266884   10.806346   8.834994   2.901084 -43.59793  172.20023        1.0
WACZ     0.177801  0.042302      geom     1.0   266   52.287774   52.895943  29.674604  27.227436 -43.94481  171.83628        1.0
EWZ      0.044714  0.011648      geom     1.0   622  106.128570  106.429520  88.470699  88.470699 -43.51271  170.85090        1.0 
``` 

You might notice that I have also included rrup, rjb, hypocentre and epicentre distance in the dataset. These are included with no space cost in the dataset because xarray is smart enough to associate all these variable according to the station ID. Here is the HDF5 structure of the new output format

![image](https://github.com/user-attachments/assets/0de7e3f6-9cea-4289-9292-096852714991)

Units are attached to the data using [pint](https://pint.readthedocs.io/en/0.6/) and [pint-xarray](https://pint-xarray.readthedocs.io/). To load the IMs with unit information:

```python
>>> import xarray as xr
>>> import pint_xarray
>>> ds = xr.open_dataset('/home/jake/Downloads/ims_new.h5', engine='h5netcdf').pint.quantify()
>>> ds
<xarray.Dataset> Size: 1MB
Dimensions:    (component: 7, station: 217, period: 31, frequency: 90)
Coordinates:
  * station    (station) <U4 3kB '042A' '051B' '051D' ... 'WTSZ' 'WVZS' 'SM1F'
  * component  (component) <U7 196B '000' '090' 'ver' ... 'rotd50' 'rotd0'
  * period     (period) float32 124B 0.01 0.02 0.03 0.04 ... 5.0 6.0 7.5 10.0
    latitude   (station) float64 2kB [deg] -42.53 -41.76 ... -43.08 -42.06
    hyp        (station) float64 2kB [km] 125.0 203.2 203.2 ... 127.0 193.2
    vs30       (station) int64 2kB [m/s] 280 300 300 333 ... 297 326 1000 1000
    longitude  (station) float64 2kB [deg] 172.8 171.6 171.6 ... 170.7 173.4
    epi        (station) float64 2kB [km] 124.7 203.0 203.0 ... 126.8 193.1
    rjb        (station) float64 2kB [km] 100.4 188.9 188.9 ... 117.4 168.1
    rrup       (station) float64 2kB [km] 100.4 188.9 188.9 ... 117.4 168.1
  * frequency  (frequency) float64 720B 0.1 0.1072 0.115 ... 43.29 46.42 49.77
Data variables:
    PGA        (component, station) float32 6kB [g_0] 0.05193 ... 0.005941
    PGV        (component, station) float32 6kB [cm/s] 5.038 2.305 ... 0.8356
    CAV        (component, station) float32 6kB [m/s] 1.956 0.7012 ... nan nan
    AI         (component, station) float64 12kB [m/s] 0.04076 0.004292 ... nan
    Ds575      (component, station) float64 12kB [s] 7.51 10.43 ... nan nan
    Ds595      (component, station) float64 12kB [s] 10.49 15.71 ... nan nan
    pSA        (component, station, period) float32 188kB [g_0] 0.05202 ... 0...
    FAS        (component, station, frequency) float64 1MB [s·g_0] 0.00825 .....
```

Then you get all kinds of superpowers. For example, suppose you want to plot the geometric component of arias intensity against rrup for all stations  with an rrup less than 100km. Then you can just do

```python
# format units to our taste
>>> ureg = pint_xarray.unit_registry
>>> ureg.default_formatter = "~P" # terse formatting output. 
>>> ds.sel(component='geom').where(ds.rrup < 100 * ureg.kilometer, drop=True).AI.plot.scatter(x='rrup')
>>> plt.title('Arias Intensity vs RRup')
>>> plt.show()
```
![test](https://github.com/user-attachments/assets/d881f69c-8efa-4aa7-b077-856b3f527e8c)

The format is self-documenting using HDF5 attributes.

```python
>>> ds.frequency
}<xarray.DataArray 'frequency' (frequency: 90)> Size: 720B
array([ 0.1     ,  0.107227,  0.114976,  0.123285,  0.132194,  0.141747,
        0.151991,  0.162975,  0.174753,  0.187382,  0.200923,  0.215443,
        0.231013,  0.247708,  0.265609,  0.284804,  0.305386,  0.327455,
        0.351119,  0.376494,  0.403702,  0.432876,  0.464159,  0.497702,
        0.53367 ,  0.572237,  0.613591,  0.657933,  0.70548 ,  0.756463,
        0.811131,  0.869749,  0.932603,  1.      ,  1.072267,  1.149757,
        1.232847,  1.321941,  1.417474,  1.519911,  1.629751,  1.747528,
        1.873817,  2.009233,  2.154435,  2.31013 ,  2.477076,  2.656088,
        2.848036,  3.053856,  3.274549,  3.511192,  3.764936,  4.037017,
        4.328761,  4.641589,  4.977024,  5.336699,  5.722368,  6.135907,
        6.579332,  7.054802,  7.564633,  8.111308,  8.69749 ,  9.326033,
       10.      , 10.722672, 11.49757 , 12.328467, 13.219411, 14.174742,
       15.199111, 16.297508, 17.475284, 18.738174, 20.09233 , 21.544347,
       23.101297, 24.770764, 26.560878, 28.480359, 30.538555, 32.745492,
       35.111917, 37.649358, 40.370173, 43.287613, 46.415888, 49.770236])
Coordinates:
  * frequency  (frequency) float64 720B 0.1 0.1072 0.115 ... 43.29 46.42 49.77
Attributes:
    description:  Frequency of motion
    units:        hertz
```
The units and description show up as attributes in the HDF5 file, so they can be read by users that are not using `xarray`
![image](https://github.com/user-attachments/assets/e86264df-c068-4ff8-a558-44ef94f9f43b)
*Above:* Units and description attributes in Panoply.