### PR TITLE
Add proportional scaling `restart_itinc` for the number of timesteps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,9 @@ empirical @ git+https://github.com/ucgmsim/Empirical_Engine.git
 fastparquet
 geopandas
 h5py
-h5netcdf
 jinja2
 networkx
 nshmdb @ git+https://github.com/ucgmsim/NSHM2022DB.git
-numba
 numexpr
 numpy<2
 pandas
@@ -14,7 +12,6 @@ printree
 pygmt
 pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper.git
 pyarrow
-pykooh
 pytest
 pyvis
 pyvista

--- a/workflow/scripts/create_e3d_par.py
+++ b/workflow/scripts/create_e3d_par.py
@@ -98,6 +98,7 @@ def emod3d_duration_parameters(
         "flo": flo,
         "dt": domain_parameters.dt,
         "ts_total": int(extended_simulation_duration / (domain_parameters.dt * dtts)),
+        "restart_itinc": round(nt / 3),
     }
 
 


### PR DESCRIPTION
As discussed with @sungeunbae and @capajaro, the restart increment should scale proportionally to the run size. I've set it up so that each run gets three dumps. Open to suggestions changing this.