### PR TITLE
Misc. Fixes for TACC

### DIFF
--- a/docker/runner/runner.def
+++ b/docker/runner/runner.def
@@ -32,8 +32,8 @@ From: ubuntu:latest
     wget "https://www.dropbox.com/scl/fi/50kww45wpsnmtf3pn2okz/nshmdb.db?rlkey=4mjuomuevl1963fjwfximgldm&st=keryhkwb&dl=0" -O /nshmdb.db
     wget "https://www.dropbox.com/scl/fi/b4m9g32x1j70ti69zyybq/genslip_velocity_model.vmod?rlkey=yxurhrdn8uvqh33hsb0inhsq0&st=o77aaccp&dl=0" -O /genslip_velocity_model.vmod
     wget "https://www.dropbox.com/scl/fi/qakchhg6qu23aclcb02ye/Cant1D_v2-midQ_leer.1d?rlkey=wn1a6nnol2eaf5n6qsy5t1nym&st=8yahw7id&dl=0" -O /Cant1D_v2-midQ_leer.1d
-    wget "https://www.dropbox.com/scl/fi/pl7mw6022faskwtfsh67w/non_uniform_whole_nz_with_real_stations-hh400_v20p3_land.vs30?rlkey=0lfk9af25nrg6r5wl5j0z9t6a&st=vgwt4sv3&dl=0" -O /stations.vs30
-    wget "https://www.dropbox.com/scl/fi/qifr4l9gmlzeqci5to1s4/non_uniform_whole_nz_with_real_stations-hh400_v20p3_land.ll?rlkey=al2afz1uh0swfekvmc56u9r89&st=p6veto2x&dl=0" -O /stations.ll
+    wget "https://www.dropbox.com/scl/fi/tw1m15owloi0eo8h3u1kw/geoNet_stats-2023-06-28.vs30?rlkey=plu90zg0ti4lc2nvf51zu9xmg&st=iz8c2ls3&dl=0" -O /stations.vs30
+    wget "https://www.dropbox.com/scl/fi/bb852b1f0rly6cfvs9p9b/geoNet_stats-2023-06-28.ll?rlkey=3y8k5qviy52nbksfdkm1n92yh&st=605h60u6&dl=0" -O /stations.ll
 
     cd /EMOD3D && \
     git checkout cylc && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jinja2
 networkx
 nshmdb @ git+https://github.com/ucgmsim/NSHM2022DB.git
 numexpr
-numpy<2
+numpy
 pandas
 printree
 pyarrow

--- a/workflow/default_parameters/v24_2_2_4/defaults.yaml
+++ b/workflow/default_parameters/v24_2_2_4/defaults.yaml
@@ -343,9 +343,7 @@ bb:
   fmin: 0.25
   site_amp_version: "2014"
 im:
-  ims: ["PGA", "PGV", "CAV", "AI", "Ds575", "Ds595", "MMI", "pSA"]
-  components: ["000", "090", "ver", "geom", "rotd50", "rotd100"]
-  units: "g"
+  ims: ["PGA", "PGV", "CAV", "AI", "Ds575", "Ds595", "pSA", "FAS"]
   valid_periods:
     [
       0.01,

--- a/workflow/scripts/hf_sim.py
+++ b/workflow/scripts/hf_sim.py
@@ -168,7 +168,10 @@ def hf_simulate_station(
         epicentre_distance = np.fromstring(output.stderr, dtype="f4", sep="\n")
         logger.info(
             log_utils.structured_log(
-                "hf succeeded", station=name, epicentre_distance=epicentre_distance
+                "hf succeeded",
+                station=name,
+                epicentre_distance=epicentre_distance,
+                stderr=output.stderr,
             )
         )
 


### PR DESCRIPTION
In summary:

- **Print `stderr` output to logs for HF simulations.** This helped debug the epicentre problem on TACC, so I will keep it in future in case a similar problem arises again.
- **Update default stations file.** To the geonet 2023 stations file list. I had previously provided the non-uniform station list but as discussed last year this is perhaps not the best stations file anymore. This can of course be overridden in simulations that need to use a different stations file. 
- **Fix 400m IM defaults to match 200m and 100m.** Just forgot to update these, nobody was running 400m simulations anyway so this shouldn't affect any runs.
- **Relax the numpy version requirement.** As part of the project to move to numpy >= 2.