### PR TITLE
Fix workflow log spam

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ schema
 scipy
 shapely
 source_modelling @ git+https://github.com/ucgmsim/source_modelling.git
+structlog
 tables
 tqdm
 typer

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -1,16 +1,13 @@
-import logging
-import re
+import concurrent.futures
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
 import pytest
+import structlog.testing
 
 from workflow import log_utils
-
-
-def test_structured_log():
-    assert log_utils.structured_log("test", a=1, b=2, c=3) == "test\ta=1\tb=2\tc=3"
 
 
 @log_utils.log_call()
@@ -18,22 +15,23 @@ def foo(a: int, b: int):
     return a + b
 
 
-def test_basic_log(caplog: pytest.LogCaptureFixture):
-    caplog.set_level(logging.INFO)
+def test_basic_log():
+    log_capture = structlog.testing.LogCapture()
+    structlog.configure(processors=[log_capture])
+
     _ = foo(1, 2)
 
-    assert len(caplog.messages) == 2
+    assert len(log_capture.entries) == 2
+    call_log = log_capture.entries[0]
+    assert call_log["event"] == "called"
+    assert call_log["function"] == "foo"
+    assert call_log["a"] == 1
+    assert call_log["b"] == 2
 
-    call_log = caplog.messages[0]
-    assert re.match(
-        "called\tfunction=foo\tid=.*\ta=1\tb=2",
-        call_log,
-    )
-    return_log = caplog.messages[1]
-    assert re.match(
-        "completed\tfunction=foo\tid=.*\tresult=3",
-        return_log,
-    )
+    return_log = log_capture.entries[1]
+    assert return_log["event"] == "completed"
+    assert return_log["function"] == "foo"
+    assert return_log["result"] == 3
 
 
 @log_utils.log_call(exclude_args={"b"})
@@ -41,22 +39,23 @@ def foo_less_b(a: int, b: int):
     return a + b
 
 
-def test_excluded_log(caplog: pytest.LogCaptureFixture):
-    caplog.set_level(logging.INFO)
+def test_excluded_log():
+    log_capture = structlog.testing.LogCapture()
+    structlog.configure(processors=[log_capture])
 
     _ = foo_less_b(1, 2)
 
-    assert len(caplog.messages) == 2
-    call_log = caplog.messages[0]
-    assert re.match(
-        "called\tfunction=foo_less_b\tid=.*\ta=1",
-        call_log,
-    )
-    return_log = caplog.messages[1]
-    assert re.match(
-        "completed\tfunction=foo_less_b\tid=.*\tresult=3",
-        return_log,
-    )
+    assert len(log_capture.entries) == 2
+    call_log = log_capture.entries[0]
+    assert call_log["event"] == "called"
+    assert call_log["function"] == "foo_less_b"
+    assert call_log["a"] == 1
+    assert "b" not in call_log
+
+    return_log = log_capture.entries[1]
+    assert return_log["event"] == "completed"
+    assert return_log["function"] == "foo_less_b"
+    assert return_log["result"] == 3
 
 
 @log_utils.log_call(action_name="FOOBAR")
@@ -64,21 +63,21 @@ def bar(a: Any):
     pass
 
 
-def test_renamed_bar(caplog: pytest.LogCaptureFixture):
-    caplog.set_level(logging.INFO)
+def test_renamed_bar():
+    log_capture = structlog.testing.LogCapture()
+    structlog.configure(processors=[log_capture])
+
     bar(1)
 
-    assert len(caplog.messages) == 2
-    call_log = caplog.messages[0]
-    assert re.match(
-        "called\tfunction=FOOBAR\tid=.*\ta=1",
-        call_log,
-    )
-    return_log = caplog.messages[1]
-    assert re.match(
-        "completed\tfunction=FOOBAR\tid=.*",
-        return_log,
-    )
+    assert len(log_capture.entries) == 2
+    call_log = log_capture.entries[0]
+    assert call_log["event"] == "called"
+    assert call_log["function"] == "FOOBAR"
+    assert call_log["a"] == 1
+
+    return_log = log_capture.entries[1]
+    assert return_log["event"] == "completed"
+    assert return_log["function"] == "FOOBAR"
 
 
 @log_utils.log_call(include_result=False)
@@ -86,21 +85,22 @@ def baz(a: Any):
     return 1
 
 
-def test_no_result(caplog: pytest.LogCaptureFixture):
-    caplog.set_level(logging.INFO)
+def test_no_result():
+    log_capture = structlog.testing.LogCapture()
+    structlog.configure(processors=[log_capture])
+
     baz(1)
 
-    assert len(caplog.messages) == 2
-    call_log = caplog.messages[0]
-    assert re.match(
-        "called\tfunction=baz\tid=.*\ta=1",
-        call_log,
-    )
-    return_log = caplog.messages[1]
-    assert re.match(
-        "completed\tfunction=baz\tid=.*",
-        return_log,
-    )
+    assert len(log_capture.entries) == 2
+    call_log = log_capture.entries[0]
+    assert call_log["event"] == "called"
+    assert call_log["function"] == "baz"
+    assert call_log["a"] == 1
+
+    return_log = log_capture.entries[1]
+    assert return_log["event"] == "completed"
+    assert return_log["function"] == "baz"
+    assert "result" not in return_log
 
 
 @log_utils.log_call()
@@ -108,41 +108,92 @@ def failing_function():
     raise ValueError("This function should fail!")
 
 
-def test_failing_function(caplog: pytest.LogCaptureFixture):
-    caplog.set_level(logging.INFO)
+def test_failing_function():
+    log_capture = structlog.testing.LogCapture()
+    structlog.configure(processors=[log_capture])
+
     with pytest.raises(ValueError):
         failing_function()
 
-    assert len(caplog.messages) == 2
-    return_log = caplog.messages[1]
-    assert re.match(
-        "failed\tfunction=failing_function\tid=.*\terror=Traceback.*", return_log
-    )
+    assert len(log_capture.entries) == 2
+    return_log = log_capture.entries[1]
+    assert return_log["event"] == "failed"
+    assert return_log["function"] == "failing_function"
+    assert "error" in return_log
 
 
-def test_successful_check_call_log(caplog: pytest.LogCaptureFixture, tmp_path: Path):
-    caplog.set_level(logging.INFO)
+def test_successful_check_call_log(tmp_path: Path):
+    log_capture = structlog.testing.LogCapture()
+    structlog.configure(processors=[log_capture])
+
     test_file = tmp_path / "test.txt"
     test_file.touch()
     log_utils.log_check_call(["ls", str(tmp_path)])
 
-    assert len(caplog.messages) == 2
-    execution_message = caplog.messages[0]
-    assert re.match("executing\tcommand=ls\targs=\\['.*'\\]\tid=.*", execution_message)
-    completion_message = caplog.messages[1]
-    assert re.match(
-        "completed\tcommand=ls\tstdout=test.txt\n\tid=.*", completion_message
-    )
+    assert len(log_capture.entries) == 2
+    execution_message = log_capture.entries[0]
+    assert execution_message["event"] == "executing"
+    assert execution_message["command"] == "ls"
+
+    completion_message = log_capture.entries[1]
+    assert completion_message["event"] == "completed"
+    assert "stdout" in completion_message and "test.txt" in completion_message["stdout"]
 
 
-def test_failing_check_call_log(caplog: pytest.LogCaptureFixture):
-    caplog.set_level(logging.INFO)
+def test_failing_check_call_log():
+    log_capture = structlog.testing.LogCapture()
+    structlog.configure(processors=[log_capture])
+
     with pytest.raises(subprocess.CalledProcessError):
         log_utils.log_check_call(["ls", "/bad-path"])
 
-    assert len(caplog.messages) == 2
-    completion_message = caplog.messages[1]
-    assert re.match(
-        "failed\tcommand=ls\tid=.*\tcode=2\tstdout=\tstderr=ls: cannot access '/bad-path': No such file or directory",
-        completion_message,
+    assert len(log_capture.entries) == 2
+    completion_message = log_capture.entries[1]
+    assert completion_message["event"] == "failed"
+    assert completion_message["command"] == "ls"
+    assert (
+        "stderr" in completion_message and "/bad-path" in completion_message["stderr"]
+    )
+
+
+def test_repeated_logs():
+    log_capture = structlog.testing.LogCapture()
+    structlog.configure(processors=[log_capture])
+
+    logger_name = "test_repeated"
+    for _ in range(3):
+        log_utils.get_logger(logger_name)
+
+    logger = log_utils.get_logger(logger_name)
+    logger.info("Test message for repeated logs")
+
+    assert (
+        sum(
+            1
+            for log in log_capture.entries
+            if log["event"] == "Test message for repeated logs"
+        )
+        == 1
+    )
+
+
+def _thread_worker(logger_name):
+    logger = log_utils.get_logger(logger_name)
+    logger.info("Threaded log message")
+
+
+def test_thread_safety():
+    log_capture = structlog.testing.LogCapture()
+    structlog.configure(processors=[log_capture])
+
+    logger_name = "test_thread"
+    num_threads = 20
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        executor.map(_thread_worker, [logger_name] * num_threads)
+
+    time.sleep(0.1)
+
+    assert (
+        sum(1 for log in log_capture.entries if log["event"] == "Threaded log message")
+        == num_threads
     )

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -177,7 +177,7 @@ def test_repeated_logs():
     )
 
 
-def _thread_worker(logger_name):
+def _thread_worker(logger_name: str):
     logger = log_utils.get_logger(logger_name)
     logger.info("Threaded log message")
 

--- a/workflow/log_utils.py
+++ b/workflow/log_utils.py
@@ -28,6 +28,7 @@ import traceback
 import uuid
 from collections.abc import Callable, Iterable
 from typing import Any, Optional
+
 import structlog
 
 # Configure structlog

--- a/workflow/log_utils.py
+++ b/workflow/log_utils.py
@@ -23,17 +23,24 @@ Examples
 
 import functools
 import inspect
-import logging
-import os
 import subprocess
 import traceback
 import uuid
 from collections.abc import Callable, Iterable
 from typing import Any, Optional
+import structlog
+
+# Configure structlog
+structlog.configure(
+    processors=[
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.JSONRenderer(),
+    ]
+)
 
 
-def get_logger(name: str) -> logging.Logger:
-    """Get a formatted logger with `name`.
+def get_logger(name: str) -> structlog.BoundLogger:
+    """Get a formatted logger with name.
 
     Parameters
     ----------
@@ -42,44 +49,10 @@ def get_logger(name: str) -> logging.Logger:
 
     Returns
     -------
-    logging.Logger
+    structlog.BoundLogger
         The logger with name `name`.
     """
-    logger = logging.getLogger(name)
-    logger.setLevel(os.environ.get("LOG_LEVEL", logging.INFO))
-    handler = logging.StreamHandler()
-    handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s\t%(levelname)s\t%(name)s\t%(threadName)s\t%(message)s"
-        )
-    )
-    logger.addHandler(handler)
-    return logger
-
-
-def structured_log(
-    message: str,
-    **kwargs: Any,
-) -> str:
-    """Format a log message in a structured logging format.
-
-    Parameters
-    ----------
-    message : str
-        The message to log.
-    **kwargs : Any
-        Keyword arguments to log in a structured logging format.
-
-    Returns
-    -------
-    str
-        A message in a structured log format
-    """
-    log_kwargs = {key: str(value) for key, value in kwargs.items()}
-    structured_log_data = "\t".join(
-        f"{key}={value}" for key, value in log_kwargs.items()
-    )
-    return f"{message}\t{structured_log_data}"
+    return structlog.get_logger(name)
 
 
 def log_call(
@@ -104,49 +77,39 @@ def log_call(
     Callable
         A decorator that logs it's wrapped function's arguments every
         time the function is called, and logs once it has completed
-        (with it's return value if `include_result` is True).
+        (with it's return value if include_result is True).
     """
 
-    def decorator(f: Callable) -> Callable: # numpydoc ignore=GL08
+    def decorator(f: Callable) -> Callable:
         @functools.wraps(f)
-        def wrapper(*args, **kwargs): # numpydoc ignore=GL08
+        def wrapper(*args, **kwargs):
             nonlocal exclude_args
             signature = inspect.signature(f)
             function_id = str(uuid.uuid4())
-            exclude_args = exclude_args or set()
+            exclude_args = set(exclude_args or [])
             name = f.__globals__["__name__"]
-            logger = get_logger(name)
+            logger = get_logger(name).bind(
+                function=action_name or f.__name__, id=function_id
+            )
+
             unified_arguments = {
                 parameter: arg
                 for parameter, arg in zip(signature.parameters, args)
                 if parameter not in exclude_args
             } | {key: value for key, value in kwargs.items() if key not in exclude_args}
-            name = action_name or f.__name__
-            logger.info(
-                structured_log(
-                    "called", function=name, id=function_id, **unified_arguments
-                )
-            )
+
+            logger.info("called", **unified_arguments)
             try:
                 result = f(*args, **kwargs)
-            except:
-                logger.error(
-                    structured_log(
-                        "failed",
-                        function=name,
-                        id=function_id,
-                        error=traceback.format_exc(),
-                    )
-                )
+            except Exception:
+                logger.error("failed", error=traceback.format_exc())
                 raise
-            if include_result and result:
-                logger.info(
-                    structured_log(
-                        "completed", function=name, id=function_id, result=result
-                    )
-                )
+
+            if include_result:
+                logger.info("completed", result=result)
             else:
-                logger.info(structured_log("completed", function=name, id=function_id))
+                logger.info("completed")
+
             return result
 
         return wrapper
@@ -176,26 +139,18 @@ def log_check_call(args: list[str], **kwargs: Any) -> str:
     """
     cmd_uuid = str(uuid.uuid4())
     name = inspect.currentframe().f_back.f_globals["__name__"]
-    logger = logging.getLogger(name)
-    logger.info(
-        structured_log("executing", command=args[0], args=args[1:], id=cmd_uuid)
-    )
+    logger = get_logger(name).bind(command=args[0], id=cmd_uuid)
+
+    logger.info("executing", args=args[1:])
     try:
         kwargs["stderr"] = subprocess.PIPE
         output = subprocess.check_output(args, **kwargs).decode("utf-8")
-        logger.info(
-            structured_log("completed", command=args[0], stdout=output, id=cmd_uuid)
-        )
+        logger.info("completed", stdout=output)
     except subprocess.CalledProcessError as e:
         logger.error(
-            structured_log(
-                "failed",
-                command=args[0],
-                id=cmd_uuid,
-                code=e.returncode,
-                stdout=e.output.decode("utf-8"),
-                stderr=e.stderr.decode("utf-8"),
-            )
+            "failed",
+            code=e.returncode,
+            stdout=e.output.decode("utf-8"),
+            stderr=e.stderr.decode("utf-8"),
         )
         raise
-    return output

--- a/workflow/log_utils.py
+++ b/workflow/log_utils.py
@@ -81,9 +81,9 @@ def log_call(
         (with it's return value if include_result is True).
     """
 
-    def decorator(f: Callable) -> Callable:
+    def decorator(f: Callable) -> Callable:  # numpydoc ignore=GL08
         @functools.wraps(f)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs):  # numpydoc ignore=GL08
             nonlocal exclude_args
             signature = inspect.signature(f)
             function_id = str(uuid.uuid4())


### PR DESCRIPTION
The workflow currently produces a lot of repeated logs in a multiprocessing context and especially when repeating calls to `log_utils.get_logger`. This creates enormous log files that are hard to read. I've narrowed this down to some peculiarities in the implementation of standard `logger`. My fix has been to migrate to [structlog](https://www.structlog.org/en/stable/index.html), which comes with a number of extra goodies like configurable JSON output. I've tried to test this, and while I am successful testing the repeated `get_logger` calls I am less successful at testing the multi-processing context. I've been restricted to testing with thread pools (but not multiprocessing pools) because it's very hard to capture stdio across multiple python processes. Might have a think about this tomorrow when I hopefully have braincells back from not being so tired.