### PR TITLE
Add log level to workflow outputs

### DIFF
--- a/workflow/log_utils.py
+++ b/workflow/log_utils.py
@@ -35,6 +35,7 @@ import structlog
 structlog.configure(
     processors=[
         structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.add_log_level,
         structlog.processors.JSONRenderer(),
     ]
 )


### PR DESCRIPTION
Small PR to add log levels to outputs of workflow stages. Essentially turning outputs from `check-srf` from
```
{"function": "check_srf", "id": "10f7fb13-02f2-481a-b671-19cc9462dce0", "realisation_ffp": "PosixPath('Darfield_Elliot_2012_Multi.json')", "srf_ffp": "PosixPath('test.srf')", "event": "called", "timestamp": "2025-02-25T03:02:39.595013Z"}
{"expected": 7.099999999999998, "actual": 7.100000006188335, "event": "SRF Magnitude", "timestamp": "2025-02-25T03:02:39.664837Z"}
{"function": "check_srf", "id": "10f7fb13-02f2-481a-b671-19cc9462dce0", "result": null, "event": "completed", "timestamp": "2025-02-25T03:02:39.665147Z"}
```
to outputs like
```
{"function": "check_srf", "id": "f26e16ec-a91a-4c79-be98-064b1c31444f", "realisation_ffp": "PosixPath('Darfield_Elliot_2012_Multi.json')", "srf_ffp": "PosixPath('test.srf')", "event": "called", "timestamp": "2025-02-25T03:16:16.286589Z", "level": "info"}
{"expected": 7.099999999999998, "actual": 7.100000006188335, "event": "SRF Magnitude", "timestamp": "2025-02-25T03:16:16.356692Z", "level": "info"}
{"function": "check_srf", "id": "f26e16ec-a91a-4c79-be98-064b1c31444f", "result": null, "event": "completed", "timestamp": "2025-02-25T03:16:16.357013Z", "level": "info"}
```

Note the addition of the `level` key to log outputs. The change is small but it means that tools like `fblog` that consume JSON logs can use the level for formatting and filtering.
