### PR TITLE
Fix(realisation-to-srf):  Typo in plane length

### DIFF
--- a/workflow/scripts/realisation_to_srf.py
+++ b/workflow/scripts/realisation_to_srf.py
@@ -164,7 +164,7 @@ def generate_fault_srf(
         srf_config.resolution,
     )
 
-    nx = sum(round(fault.length / srf_config.resolution) for plane in fault.planes)
+    nx = sum(round(plane.length / srf_config.resolution) for plane in fault.planes)
     ny = round(fault.planes[0].width / srf_config.resolution)
 
     genslip_hypocentre_coords = np.array([fault.length, fault.width]) * (


### PR DESCRIPTION
Small but important PR. I added a change to fix SRF generation but introduced a bug that results in miscalculating the number of SRF points in the fault. Shouldn't cause a problem for existing researcher SRFs because no one to my knowledge is using more than one plane per fault (except me generating alpine ruptures today).