### PR TITLE
Increase fault geometry buffer to 2km

### DIFF
--- a/workflow/scripts/gcmt_auto_simulate.py
+++ b/workflow/scripts/gcmt_auto_simulate.py
@@ -26,6 +26,7 @@ For More Help
 -------------
 See the output of `python gcmt_auto_simulate.py --help` for more details on the command-line arguments.
 """
+
 import datetime
 import json
 import subprocess
@@ -40,7 +41,7 @@ import shapely
 import typer
 from shapely import Polygon
 
-from qcore import cli, coordinates, data
+from qcore import cli, coordinates, gmt
 
 app = typer.Typer()
 
@@ -53,7 +54,7 @@ def get_nz_outline_polygon() -> Polygon:
     Polygon
         The outline polygon of New Zealand.
     """
-    coastline_path = resources.files(data) / "Paths" / "coastline" / "NZ.gmt"
+    coastline_path = gmt.GMT_DATA.fetch("data/Paths/coastline/NZ.gmt")
 
     gpd_df = gpd.read_file(coastline_path)
     island_polygons = [

--- a/workflow/scripts/gcmt_auto_simulate.py
+++ b/workflow/scripts/gcmt_auto_simulate.py
@@ -30,7 +30,6 @@ See the output of `python gcmt_auto_simulate.py --help` for more details on the 
 import datetime
 import json
 import subprocess
-from importlib import resources
 from pathlib import Path
 from typing import Annotated
 

--- a/workflow/scripts/generate_velocity_model_parameters.py
+++ b/workflow/scripts/generate_velocity_model_parameters.py
@@ -271,9 +271,9 @@ def generate_velocity_model_parameters(
 
     # Get bounding box
 
-    # This polygon includes all the faults corners + a 1km buffer (which must be in the simulation domain).
+    # This polygon includes all the faults corners + a 2km buffer (which must be in the simulation domain).
     fault_buffer_polygons = [
-        shapely.buffer(fault.geometry, 1000)
+        shapely.buffer(fault.geometry, 2000)
         for fault in source_config.source_geometries.values()
     ]
 

--- a/workflow/scripts/generate_velocity_model_parameters.py
+++ b/workflow/scripts/generate_velocity_model_parameters.py
@@ -26,7 +26,6 @@ For More Help
 See the output of `generate-velocity-model-parameters --help` or `workflow.scripts.generate_velocity_model_parameters`.
 """
 
-from importlib import resources
 from pathlib import Path
 from typing import Annotated
 

--- a/workflow/scripts/generate_velocity_model_parameters.py
+++ b/workflow/scripts/generate_velocity_model_parameters.py
@@ -40,7 +40,7 @@ from shapely import Polygon
 
 from empirical.util import z_model_calculations
 from empirical.util.classdef import GMM, TectType
-from qcore import cli, coordinates, data
+from qcore import cli, coordinates, gmt
 from qcore.uncertainties import mag_scaling
 from source_modelling import sources
 from velocity_modelling import bounding_box
@@ -65,7 +65,7 @@ def get_nz_outline_polygon() -> Polygon:
     Polygon
         The outline polygon of New Zealand.
     """
-    coastline_path = resources.files(data) / "Paths" / "coastline" / "NZ.gmt"
+    coastline_path = gmt.GMT_DATA.fetch("data/Paths/coastline/NZ.gmt")
 
     gpd_df = gpd.read_file(coastline_path)
     island_polygons = [


### PR DESCRIPTION
When generating a velocity model domain, we add previously added a 1km buffer around the fault geometry so that the fault is never too close to the edge of the domain. This PR bumps the buffer to 2km on the suggestion Brendon in last Monday's researcher meeting. The increase is to ensure that the geometry is also well-clear of the 10 boundary gridpoints that EMOD3D applies aggressive LF attenuation to avoid wave reflections off the boundary of the domain. If the source was contained in this boundary area, then the simulation results would be distorted.