### PR TITLE
Add more scaling relationships 

### DIFF
--- a/workflow/scripts/gcmt_to_realisation.py
+++ b/workflow/scripts/gcmt_to_realisation.py
@@ -78,29 +78,6 @@ class SamplingStrategy(StrEnum):
     """Use the solution centroid."""
 
 
-def adjust_plane_above_ground(plane: sources.Plane) -> sources.Plane:
-    """Shift a plane along it's dip direction so that the top edge is at ground-level.
-
-    Parameters
-    ----------
-    plane : sources.Plane
-        The plane to shift.
-
-    Returns
-    -------
-    sources.Plane
-        The shifted plane. The plane is shifted along its dip
-        direction so that the top edge is at ground-level.
-    """
-
-    overhang = -plane.bounds[:, 2].min()
-    length = overhang / np.sin(np.radians(plane.dip))
-    dip_direction = plane.bounds[-1] - plane.bounds[0]
-    dip_direction /= np.linalg.norm(dip_direction)
-    dip_direction *= length
-    return sources.Plane(plane.bounds + dip_direction)
-
-
 @cli.from_docstring(app)
 def gcmt_to_realisation(
     gcmt_event_id: Annotated[str, typer.Argument()],
@@ -225,12 +202,13 @@ def gcmt_to_realisation(
         width,
         strike=selected_nodal_plane.strike,
     )
+
     if plane.bounds[:, 2].min() < 0:
         warnings.warn(
             f"Scaling relationship produced a plane with negative depth ({plane.bounds[:, 2].min()/1000:.2f}km)."
-            " Shifting the plane down to correct. This will affect the in-plane hypocentre coordinates!"
+            " Shifting the plane down to correct."
         )
-        plane = adjust_plane_above_ground(plane)
+        plane.bounds[:, 2] -= plane.bounds[:, 2].min()
 
     if lat_hypo is not None and lon_hypo is not None:
         hypocentre = plane.wgs_depth_coordinates_to_fault_coordinates(
@@ -253,9 +231,7 @@ def gcmt_to_realisation(
             ]
         )
     else:
-        hypocentre = plane.wgs_depth_coordinates_to_fault_coordinates(
-            centroid * np.array([1, 1, 1000])
-        )
+        hypocentre = np.array([1 / 2, 1 / 2])
 
     source_config = SourceConfig(
         source_geometries={gcmt_event_id: sources.Fault([plane])}

--- a/workflow/scripts/gcmt_to_realisation.py
+++ b/workflow/scripts/gcmt_to_realisation.py
@@ -28,10 +28,11 @@ For More Help
 See the output of `gcmt-to-realisation --help`.
 """
 
+import warnings
 from collections.abc import Callable
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import Annotated, Any, Optional
+from typing import Annotated, Optional
 
 import numpy as np
 import pandas as pd
@@ -39,7 +40,7 @@ import requests
 import typer
 
 from qcore import cli
-from qcore.uncertainties import distributions, mag_scaling
+from qcore.uncertainties import distributions
 from source_modelling import community_fault_model, magnitude_scaling, sources
 from source_modelling.community_fault_model import NodalPlane
 from workflow.defaults import DefaultsVersion
@@ -199,6 +200,12 @@ def gcmt_to_realisation(
         width,
         strike=selected_nodal_plane.strike,
     )
+    if plane.bounds[:, 2].min() < 0:
+        warnings.warn(
+            f"Scaling relationship produced a plane with negative depth ({plane.bounds[:, 2].min()/1000:.2f}km)."
+            " Shifting the plane down to correct. This will affect the centroid depth!"
+        )
+        plane.bounds[:, 2] -= plane.bounds[:, 2].min()
     if lat_hypo is not None and lon_hypo is not None:
         hypocentre_global = np.array([lat_hypo, lon_hypo])
         hypocentre = plane.wgs_depth_coordinates_to_fault_coordinates(hypocentre_global)

--- a/workflow/scripts/gcmt_to_realisation.py
+++ b/workflow/scripts/gcmt_to_realisation.py
@@ -28,9 +28,10 @@ For More Help
 See the output of `gcmt-to-realisation --help`.
 """
 
+from collections.abc import Callable
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -39,7 +40,7 @@ import typer
 
 from qcore import cli
 from qcore.uncertainties import distributions, mag_scaling
-from source_modelling import community_fault_model, sources
+from source_modelling import community_fault_model, magnitude_scaling, sources
 from source_modelling.community_fault_model import NodalPlane
 from workflow.defaults import DefaultsVersion
 from workflow.realisations import (
@@ -63,6 +64,17 @@ class SamplingStrategy(StrEnum):
     """Random sample from the distribution."""
 
 
+class NodalPlaneChoice(StrEnum):
+    """Index for the nodal plane."""
+
+    PLANE_1 = auto()
+    """First nodal plane."""
+    PLANE_2 = auto()
+    """Second nodal plane."""
+    MOST_LIKELY = auto()
+    """Most likely nodal plane based on the community fault model."""
+
+
 @cli.from_docstring(app)
 def gcmt_to_realisation(
     gcmt_event_id: Annotated[str, typer.Argument()],
@@ -82,8 +94,11 @@ def gcmt_to_realisation(
         typer.Option(min=-180, max=180),
     ] = None,
     scaling_relation: Annotated[
-        mag_scaling.MagnitudeScalingRelations, typer.Option(case_sensitive=False)
-    ] = mag_scaling.MagnitudeScalingRelations.LEONARD2014,
+        magnitude_scaling.ScalingRelation, typer.Option(case_sensitive=False)
+    ] = magnitude_scaling.ScalingRelation.LEONARD2014,
+    nodal_plane: Annotated[
+        NodalPlaneChoice, typer.Option()
+    ] = NodalPlaneChoice.MOST_LIKELY,
 ):
     """Generate a realisation from a GCMT solution.
 
@@ -105,8 +120,15 @@ def gcmt_to_realisation(
         The latitude coordinate of the hypocentre. Conflicts with shypo and dhypo.
     lon_hypo : float, optional
         The latitude coordinate of the hypocentre. Conflicts with shypo and dhypo.
-    scaling_relation : mag_scaling.MagnitudeScalingRelations
-        The magnitude scaling relation to use.
+    scaling_relation : magnitude_scaling.ScalingRelation or callable, optional
+        Either the name of the magnitude scaling relation from source
+        modelling to use, or a callable function that takes a
+        magnitude and returns a tuple `(length, width)`. Used for custom
+        scaling relations.
+    nodal_plane : NodalPlaneChoice
+        The nodal plane to use. Most likely will use the community fault model to
+        choose a nodal plane that agrees with the tectonic fabric.
+        Defaults to `MOST_LIKELY`.
     """
     if (shypo is not None or dhypo is not None) and (
         lat_hypo is not None or lon_hypo is not None
@@ -149,13 +171,26 @@ def gcmt_to_realisation(
         )
 
     model = community_fault_model.get_community_fault_model()
-    selected_nodal_plane = community_fault_model.most_likely_nodal_plane(
-        model, np.array([latitude, longitude]), nodal_plane_1, nodal_plane_2
-    )
+
+    match nodal_plane:
+        case NodalPlaneChoice.PLANE_1:
+            selected_nodal_plane = nodal_plane_1
+        case NodalPlaneChoice.PLANE_2:
+            selected_nodal_plane = nodal_plane_2
+        case NodalPlaneChoice.MOST_LIKELY:
+            selected_nodal_plane = community_fault_model.most_likely_nodal_plane(
+                model, np.array([latitude, longitude]), nodal_plane_1, nodal_plane_2
+            )
+
     rake = selected_nodal_plane.rake
-    length, width = mag_scaling.mw_to_lw_scaling_relation(
-        magnitude, scaling_relation, rake
-    )
+
+    if isinstance(scaling_relation, str):
+        length, width = magnitude_scaling.magnitude_to_length_width(
+            scaling_relation, magnitude, rake
+        )
+    elif isinstance(scaling_relation, Callable):
+        length, width = scaling_relation(magnitude)
+
     centroid = np.array([latitude, longitude, centroid_depth])
     plane = sources.Plane.from_centroid_strike_dip(
         centroid,

--- a/workflow/scripts/gcmt_to_realisation.py
+++ b/workflow/scripts/gcmt_to_realisation.py
@@ -56,6 +56,17 @@ NAN_PUBLIC_ID = "9999999"
 app = typer.Typer()
 
 
+class NodalPlaneChoice(StrEnum):
+    """Nodal plane choice for GCMT solutions."""
+
+    PLANE_1 = auto()
+    """First nodal plane."""
+    PLANE_2 = auto()
+    """Second nodal plane."""
+    MOST_LIKELY = auto()
+    """The most likely nodal plane estimated from the community fault model."""
+
+
 class SamplingStrategy(StrEnum):
     """Sampling strategy for hypocentre location."""
 
@@ -63,17 +74,31 @@ class SamplingStrategy(StrEnum):
     """Average of the distribution."""
     RANDOM = auto()
     """Random sample from the distribution."""
+    CENTROID = auto()
+    """Use the solution centroid."""
 
 
-class NodalPlaneChoice(StrEnum):
-    """Index for the nodal plane."""
+def adjust_plane_above_ground(plane: sources.Plane) -> sources.Plane:
+    """Shift a plane along it's dip direction so that the top edge is at ground-level.
 
-    PLANE_1 = auto()
-    """First nodal plane."""
-    PLANE_2 = auto()
-    """Second nodal plane."""
-    MOST_LIKELY = auto()
-    """Most likely nodal plane based on the community fault model."""
+    Parameters
+    ----------
+    plane : sources.Plane
+        The plane to shift.
+
+    Returns
+    -------
+    sources.Plane
+        The shifted plane. The plane is shifted along its dip
+        direction so that the top edge is at ground-level.
+    """
+
+    overhang = -plane.bounds[:, 2].min()
+    length = overhang / np.sin(np.radians(plane.dip))
+    dip_direction = plane.bounds[-1] - plane.bounds[0]
+    dip_direction /= np.linalg.norm(dip_direction)
+    dip_direction *= length
+    return sources.Plane(plane.bounds + dip_direction)
 
 
 @cli.from_docstring(app)
@@ -83,7 +108,7 @@ def gcmt_to_realisation(
     realisation_ffp: Annotated[Path, typer.Argument(writable=True, dir_okay=False)],
     hypocentre_strategy: Annotated[
         SamplingStrategy, typer.Option()
-    ] = SamplingStrategy.AVERAGE,
+    ] = SamplingStrategy.CENTROID,
     shypo: Annotated[Optional[float], typer.Option(min=0, max=1)] = None,
     dhypo: Annotated[Optional[float], typer.Option(min=0, max=1)] = None,
     lat_hypo: Annotated[
@@ -203,24 +228,34 @@ def gcmt_to_realisation(
     if plane.bounds[:, 2].min() < 0:
         warnings.warn(
             f"Scaling relationship produced a plane with negative depth ({plane.bounds[:, 2].min()/1000:.2f}km)."
-            " Shifting the plane down to correct. This will affect the centroid depth!"
+            " Shifting the plane down to correct. This will affect the in-plane hypocentre coordinates!"
         )
-        plane.bounds[:, 2] -= plane.bounds[:, 2].min()
+        plane = adjust_plane_above_ground(plane)
+
     if lat_hypo is not None and lon_hypo is not None:
-        hypocentre_global = np.array([lat_hypo, lon_hypo])
-        hypocentre = plane.wgs_depth_coordinates_to_fault_coordinates(hypocentre_global)
+        hypocentre = plane.wgs_depth_coordinates_to_fault_coordinates(
+            np.array([lat_hypo, lon_hypo])
+        )
+    elif shypo is not None and dhypo is not None:
+        hypocentre = np.array([shypo, dhypo])
+    elif hypocentre_strategy == SamplingStrategy.AVERAGE:
+        hypocentre = np.array(
+            [
+                1 / 2,
+                distributions.truncated_weibull_expected_value(1),
+            ]
+        )
+    elif hypocentre_strategy == SamplingStrategy.RANDOM:
+        hypocentre = np.array(
+            [
+                distributions.truncated_normal(1 / 2, 1 / 4),
+                distributions.truncated_weibull(1),
+            ]
+        )
     else:
-        default_shypo = (
-            1 / 2
-            if hypocentre_strategy == SamplingStrategy.AVERAGE
-            else distributions.truncated_normal(1 / 2, 1 / 4)
+        hypocentre = plane.wgs_depth_coordinates_to_fault_coordinates(
+            centroid * np.array([1, 1, 1000])
         )
-        default_dhypo = (
-            distributions.truncated_weibull_expected_value(1)
-            if hypocentre_strategy == SamplingStrategy.AVERAGE
-            else distributions.truncated_weibull(1)
-        )
-        hypocentre = np.array([shypo or default_shypo, dhypo or default_dhypo])
 
     source_config = SourceConfig(
         source_geometries={gcmt_event_id: sources.Fault([plane])}

--- a/workflow/scripts/gcmt_to_realisation.py
+++ b/workflow/scripts/gcmt_to_realisation.py
@@ -210,7 +210,7 @@ def gcmt_to_realisation(
 
     rake = selected_nodal_plane.rake
 
-    if isinstance(scaling_relation, str):
+    if isinstance(scaling_relation, str | magnitude_scaling.ScalingRelation):
         length, width = magnitude_scaling.magnitude_to_length_width(
             scaling_relation, magnitude, rake
         )


### PR DESCRIPTION
Allows researchers to provide custom scaling relationships, override the nodal plane selection, and fix a bug if the centroid depth is too shallow. The custom scaling relationships are passed as functions (i.e. the researcher would write could to implement a new scaling relationship). Passing a scaling relation from source_modelling will use one of the three Cybershake-ready scaling relationships (Leonard, Contreras Slab & Interface). This change ensures that researchers like Cesar can play with different scaling relations, but doesn't require the software team to implement every one and verify correctness to the same standard as the Cybershake scaling relations.