### PR TITLE
Log run commands to realisation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ workflow = "workflow"
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 
+[tool.setuptools_scm]
+
+
 [tool.ruff.lint]
 extend-select = [
     # isort imports

--- a/tests/test_realisation.py
+++ b/tests/test_realisation.py
@@ -3,7 +3,9 @@
 # it stays consistent with the codebase.
 import json
 import struct
+from datetime import datetime
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -381,6 +383,125 @@ def test_broadband_parameters(tmp_path: Path):
         realisations.BroadbandParameters.read_from_realisation(test_realisation)
         == broadband_parameters
     )
+
+
+def test_logtrail_init_empty():
+    """Test LogTrail initialization with no log provided."""
+    trail = realisations.LogTrail([])
+    assert trail.log == []
+    assert trail._config_key == "log_trail"
+
+
+def test_logtrail_init_with_log_entries():
+    """Test LogTrail initialization with a list of LogEntry objects."""
+    entry1 = realisations.LogEntry(
+        utility="util1", args=["a"], version="1", timestamp=datetime.now()
+    )
+    entry2 = realisations.LogEntry(
+        utility="util2", args=["b", "c"], timestamp=datetime.now(), version="1"
+    )
+    trail = realisations.LogTrail(log=[entry1, entry2])
+    assert trail.log == [entry1, entry2]
+
+
+def test_logtrail_init_with_dicts_post_init():
+    """Test LogTrail post_init conversion of dicts to LogEntry objects."""
+    log_data = [
+        {
+            "utility": "util1",
+            "args": ["a"],
+            "version": "1",
+            "timestamp": datetime.now().isoformat(),
+        },
+        {
+            "utility": "util2",
+            "args": ["b"],
+            "version": "1",
+            "timestamp": datetime.now().isoformat(),
+        },
+    ]
+    # Pass raw list of dicts
+    trail = realisations.LogTrail(log=log_data)
+    assert len(trail.log) == 2
+    assert isinstance(trail.log[0], realisations.LogEntry)
+    assert isinstance(trail.log[1], realisations.LogEntry)
+    assert trail.log[0].utility == "util1"
+    assert trail.log[0].args == ["a"]
+    assert trail.log[1].utility == "util2"
+    assert trail.log[1].args == ["b"]
+
+
+def test_logtrail_log_entry_method():
+    """Test adding an entry using the log_entry method."""
+    trail = realisations.LogTrail([])
+    trail.log_entry("my_util", ["--flag", "value"])
+    assert len(trail.log) == 1
+    assert isinstance(trail.log[0], realisations.LogEntry)
+    assert trail.log[0].utility == "my_util"
+    assert trail.log[0].args == ["--flag", "value"]
+    assert isinstance(trail.log[0].timestamp, datetime)
+
+
+def test_logtrail_to_dict():
+    """Test converting LogTrail to a dictionary."""
+    ts = datetime.now()
+    entry1 = realisations.LogEntry(
+        utility="util1", args=["a"], version="1", timestamp=ts
+    )
+    entry2 = realisations.LogEntry(
+        utility="util2", args=["b", "c"], timestamp=ts, version="1"
+    )
+    trail = realisations.LogTrail(log=[entry1, entry2])
+    trail_dict = trail.to_dict()
+
+    assert isinstance(trail_dict, dict)
+    assert "log" in trail_dict
+    assert len(trail_dict["log"]) == 2
+    # Check if realisations.LogEntry objects were converted back to dicts with ISO timestamps
+    assert isinstance(trail_dict["log"][0], dict)
+    assert trail_dict["log"][0]["utility"] == "util1"
+    assert trail_dict["log"][0]["version"] == "1"
+    assert trail_dict["log"][0]["timestamp"] == ts.isoformat()
+    assert trail_dict["log"][0]["args"] == ["a"]
+    assert isinstance(
+        trail_dict["log"][0]["timestamp"], str
+    )  # Should be ISO format string
+    assert isinstance(trail_dict["log"][1], dict)
+    assert trail_dict["log"][1]["utility"] == "util2"
+    assert trail_dict["log"][1]["args"] == ["b", "c"]
+    assert trail_dict["log"][1]["version"] == "1"
+    assert trail_dict["log"][1]["timestamp"] == ts.isoformat()
+    assert isinstance(
+        trail_dict["log"][1]["timestamp"], str
+    )  # Should be ISO format string
+
+    datetime.fromisoformat(trail_dict["log"][0]["timestamp"])
+
+
+def test_append_log_entry_file_exists_no_key(
+    tmp_path: Path,
+):
+    """Test append_log_entry when file exists but lacks the 'log_trail' key."""
+    realisation_file = tmp_path / "test_realisation.json"
+    # Create a file with unrelated content
+    initial_content = {"other_key": "some_value"}
+    with open(realisation_file, "w") as f:
+        json.dump(initial_content, f)
+
+    # Mock realisations.LogEntry.from_utility for the creation case
+    with mock.patch("sys.argv", new=["script_name.py", "--flag", "value"]):
+        realisations.append_log_entry(realisation_file)
+
+    # Optionally: Check the file content (if not mocking write_to_realisation)
+    assert realisation_file.exists()
+    with open(realisation_file, "r") as f:
+        data = json.load(f)
+    assert "log_trail" in data
+    assert (
+        "other_key" in data
+    )  # Check if update worked (depends on write_to_realisation mock/impl)
+    assert len(data["log_trail"]["log"]) == 1
+    assert data["log_trail"]["log"][0]["utility"] == "script_name.py"
 
 
 def test_seeds():

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -95,12 +95,12 @@ class RealisationConfiguration(ABC):
         return dataclasses.asdict(self)
 
     @classmethod
-    def read_from_realisation(cls, realisation_ffp: Path) -> Self:
+    def read_from_realisation(cls, realisation_ffp: Path | str) -> Self:
         """Read configuration from a realisation file.
 
         Parameters
         ----------
-        realisation_ffp : Path
+        realisation_ffp : Path-like
             The filepath to read from.
 
         Returns
@@ -117,6 +117,7 @@ class RealisationConfiguration(ABC):
             If the key in `cls._config_key` is not present in
             the realisation filepath.
         """
+        realisation_ffp = Path(realisation_ffp)
         with open(realisation_ffp, "r", encoding="utf-8") as realisation_file_handle:
             realisation_config = json.load(realisation_file_handle)
             if cls._config_key not in realisation_config:
@@ -156,13 +157,13 @@ class RealisationConfiguration(ABC):
 
     @classmethod
     def read_from_realisation_or_defaults(
-        cls, realisation_ffp: Path, defaults_version: DefaultsVersion
+        cls, realisation_ffp: Path | str, defaults_version: DefaultsVersion
     ) -> Self:
         """Read configuration from realisation, or read from defaults and write to realisation.
 
         Parameters
         ----------
-        realisation_ffp : Path
+        realisation_ffp : Path-like
                     The realisation filepath to read from.
         defaults_version : DefaultsVersion
             The default parameter version to load with.
@@ -181,6 +182,7 @@ class RealisationConfiguration(ABC):
             If the key in `cls._config_key` is not present in
             the realisation or scientific defaults configuration.
         """
+        realisation_ffp = Path(realisation_ffp)
         try:
             return cls.read_from_realisation(realisation_ffp)
         except (RealisationParseError, FileNotFoundError):
@@ -188,7 +190,9 @@ class RealisationConfiguration(ABC):
             default_config.write_to_realisation(realisation_ffp)
             return default_config
 
-    def write_to_realisation(self, realisation_ffp: Path, update: bool = True) -> None:
+    def write_to_realisation(
+        self, realisation_ffp: Path | str, update: bool = True
+    ) -> None:
         """Write a configuration to a realisation file.
 
         The default behaviour will update the realisation and replace just
@@ -198,12 +202,13 @@ class RealisationConfiguration(ABC):
 
         Parameters
         ----------
-        realisation_ffp : Path
+        realisation_ffp : Path-like
             The realisation filepath to write to.
         update : bool
             If True, then the realisation is updated, rather than
             replaced. Default is True.
         """
+        realisation_ffp = Path(realisation_ffp)
         realisation_configuration = {}
         if realisation_ffp.exists() and update:
             with open(

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -847,6 +847,7 @@ class LogEntry:
     """The arguments passed to the utility."""
 
     def __post_init__(self) -> None:
+        """Post-initialisation of the log entry."""
         if isinstance(self.timestamp, str):
             self.timestamp = datetime.datetime.fromisoformat(self.timestamp)
 
@@ -858,8 +859,6 @@ class LogEntry:
         ----------
         utility : str
             The name of the utility.
-        version : str
-            The version of the utility.
         args : list[str]
             The arguments passed to the utility.
 
@@ -927,10 +926,6 @@ def append_log_entry(realisation_ffp: Path | str) -> None:
     ----------
     realisation_ffp : Path-like
         The realisation filepath to write to.
-    utility : str
-        The name of the utility.
-    args : list[str]
-        The arguments passed to the utility.
     """
     realisation_ffp = Path(realisation_ffp)
     utility = Path(sys.argv[0]).name

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -9,9 +9,12 @@ module become an "everything" module.
 """
 
 import dataclasses
+import datetime
+import importlib
 import json
 import random
 import struct
+import sys
 from abc import ABC
 from pathlib import Path
 from typing import Any, ClassVar, Literal, Optional, Self, Union
@@ -828,3 +831,116 @@ class IntensityMeasureCalculationParameters(RealisationConfiguration):
         _dict["valid_periods"] = self.valid_periods.tolist()
         _dict["fas_frequencies"] = self.fas_frequencies.tolist()
         return _dict
+
+
+@dataclasses.dataclass
+class LogEntry:
+    """Log entry for workflow utilities."""
+
+    utility: str
+    """The name of the utility."""
+    version: str
+    """The version of the utility."""
+    timestamp: datetime.datetime
+    """The timestamp of when the utility was run."""
+    args: list[str]
+    """The arguments passed to the utility."""
+
+    def __post_init__(self) -> None:
+        if isinstance(self.timestamp, str):
+            self.timestamp = datetime.datetime.fromisoformat(self.timestamp)
+
+    @classmethod
+    def from_utility(cls, utility: str, args: list[str]) -> Self:
+        """Create a log entry from a utility.
+
+        Parameters
+        ----------
+        utility : str
+            The name of the utility.
+        version : str
+            The version of the utility.
+        args : list[str]
+            The arguments passed to the utility.
+
+        Returns
+        -------
+        LogEntry
+            A log entry for the utility.
+        """
+        version = importlib.metadata.version(__package__)
+        return cls(
+            utility=utility,
+            version=version,
+            timestamp=datetime.datetime.now(),
+            args=args,
+        )
+
+
+@dataclasses.dataclass
+class LogTrail(RealisationConfiguration):
+    """Log of workflow utilities executed on this file."""
+
+    _config_key: ClassVar[str] = "log_trail"
+    _schema: ClassVar[Schema] = schemas.LOG_TRAIL_SCHEMA
+
+    log: list[LogEntry]
+
+    def __post_init__(self) -> None:
+        """Post-initialisation of the log trail."""
+        if self.log is None:
+            self.log = []
+        if self.log and not isinstance(self.log[0], LogEntry):
+            self.log = [LogEntry(**log_entry) for log_entry in self.log]
+
+    def log_entry(self, utility: str, args: list[str]) -> None:
+        """Add a log entry to the log trail.
+
+        Parameters
+        ----------
+        utility : str
+            The name of the utility.
+        args : list[str]
+            The arguments passed to the utility.
+        """
+        self.log.append(LogEntry.from_utility(utility, args))
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Convert the object to a dictionary representation.
+
+        Returns
+        -------
+        dict
+            Dictionary representation of the object.
+        """
+        config_dict = dataclasses.asdict(self)
+        for entry in config_dict["log"]:
+            entry["timestamp"] = entry["timestamp"].isoformat()
+        return config_dict
+
+
+def append_log_entry(realisation_ffp: Path | str) -> None:
+    """Append a log entry to the realisation file.
+
+    Parameters
+    ----------
+    realisation_ffp : Path-like
+        The realisation filepath to write to.
+    utility : str
+        The name of the utility.
+    args : list[str]
+        The arguments passed to the utility.
+    """
+    realisation_ffp = Path(realisation_ffp)
+    utility = Path(sys.argv[0]).name
+    args = sys.argv[1:]
+    log_entry = LogEntry.from_utility(utility, args)
+
+    try:
+        log_trail = LogTrail.read_from_realisation(realisation_ffp)
+        log_trail.log_entry(utility, args)
+    except (RealisationParseError, FileNotFoundError):
+        log_trail = LogTrail(log=[log_entry])
+
+    log_trail.write_to_realisation(realisation_ffp)

--- a/workflow/schemas.py
+++ b/workflow/schemas.py
@@ -601,3 +601,33 @@ INTENSITY_MEASURE_CALCUATION_PARAMETERS = Schema(
         ),
     }
 )
+
+
+LOG_ENTRY_SCHEMA = Schema(
+    {
+        Literal(
+            "utility",
+            description="The name of the utility that produced this log entry.",
+        ): str,
+        Literal("version", description="The version of the utility."): str,
+        Literal(
+            "timestamp",
+            description="The timestamp of when the utility was run.",
+        ): str,
+        Optional(
+            Literal(
+                "args",
+                description="The arguments the utility was executed with.",
+            )
+        ): [str],
+    }
+)
+
+LOG_TRAIL_SCHEMA = Schema(
+    {
+        Literal(
+            "log",
+            description="The utilities executed on this realisation.",
+        ): [LOG_ENTRY_SCHEMA],
+    }
+)

--- a/workflow/scripts/bb_sim.py
+++ b/workflow/scripts/bb_sim.py
@@ -51,7 +51,7 @@ import scipy as sp
 import typer
 
 from qcore import cli, siteamp_models, timeseries
-from workflow import log_utils, utils
+from workflow import log_utils, realisations, utils
 from workflow.realisations import (
     BroadbandParameters,
     DomainParameters,
@@ -329,3 +329,4 @@ def combine_hf_and_lf(
     stations["z"] = lf.stations.z
     stations["lf_vs_ref"] = lfvs30refs
     stations.to_hdf(output_ffp, key="stations", mode="a")
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/check_domain.py
+++ b/workflow/scripts/check_domain.py
@@ -35,7 +35,7 @@ import typer
 
 from qcore import cli
 from source_modelling import srf
-from workflow import log_utils
+from workflow import log_utils, realisations
 from workflow.realisations import DomainParameters
 
 app = typer.Typer()
@@ -98,3 +98,5 @@ def check_domain(
             expected_size=velocity_model_estimated_size,
         )
         raise typer.Exit(code=1)
+
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/check_srf.py
+++ b/workflow/scripts/check_srf.py
@@ -38,7 +38,7 @@ import typer
 from qcore import cli
 from qcore.uncertainties import mag_scaling
 from source_modelling import srf
-from workflow import log_utils
+from workflow import log_utils, realisations
 from workflow.realisations import (
     RealisationMetadata,
     RealisationParseError,
@@ -148,3 +148,4 @@ def check_srf(
     if srf_magnitude >= 11:
         logger.error("Implausible SRF magnitude", srf_magnitude=magnitude)
         raise typer.Exit(code=1)
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/copy_velocity_model_parameters.py
+++ b/workflow/scripts/copy_velocity_model_parameters.py
@@ -64,4 +64,4 @@ def copy_domain(
         VelocityModelParameters.read_from_realisation(from_realisation_ffp)
     )
     from_realisation_velocity_model_parameters.write_to_realisation(to_realisation_ffp)
-    realisations.append_log_entry(realisation_ffp)
+    realisations.append_log_entry(to_realisation_ffp)

--- a/workflow/scripts/copy_velocity_model_parameters.py
+++ b/workflow/scripts/copy_velocity_model_parameters.py
@@ -25,13 +25,14 @@ For More Help
 -------------
 See the output of `copy-domain --help`.
 """
+
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
 from qcore import cli
-from workflow import log_utils
+from workflow import log_utils, realisations
 from workflow.realisations import DomainParameters, VelocityModelParameters
 
 app = typer.Typer()
@@ -63,3 +64,4 @@ def copy_domain(
         VelocityModelParameters.read_from_realisation(from_realisation_ffp)
     )
     from_realisation_velocity_model_parameters.write_to_realisation(to_realisation_ffp)
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/create_e3d_par.py
+++ b/workflow/scripts/create_e3d_par.py
@@ -35,6 +35,7 @@ import numpy as np
 import typer
 
 from qcore import cli
+from workflow import realisations
 from workflow.realisations import (
     DomainParameters,
     EMOD3DParameters,
@@ -229,15 +230,29 @@ def format_as_emod3d_value(value: int | float | str | Path) -> str:
 
 @cli.from_docstring(app)
 def create_e3d_par(
-    realisation_ffp: Annotated[Path, typer.Argument(exists=True, readable=True, dir_okay=False)],
-    srf_file_ffp: Annotated[Path, typer.Argument(exists=True, readable=True, dir_okay=False)],
-    velocity_model_ffp: Annotated[Path, typer.Argument(exists=True, readable=True, file_okay=False)],
-    stations_ffp: Annotated[Path, typer.Argument(exists=True, readable=True, file_okay=False)],
-    grid_ffp: Annotated[Path, typer.Argument(exists=True, readable=True, file_okay=False)],
+    realisation_ffp: Annotated[
+        Path, typer.Argument(exists=True, readable=True, dir_okay=False)
+    ],
+    srf_file_ffp: Annotated[
+        Path, typer.Argument(exists=True, readable=True, dir_okay=False)
+    ],
+    velocity_model_ffp: Annotated[
+        Path, typer.Argument(exists=True, readable=True, file_okay=False)
+    ],
+    stations_ffp: Annotated[
+        Path, typer.Argument(exists=True, readable=True, file_okay=False)
+    ],
+    grid_ffp: Annotated[
+        Path, typer.Argument(exists=True, readable=True, file_okay=False)
+    ],
     output_ffp: Annotated[Path, typer.Argument(writable=True, file_okay=False)],
-    scratch_ffp: Annotated[Path, typer.Option(writable=True, file_okay=False)] = Path("/out"),
+    scratch_ffp: Annotated[Path, typer.Option(writable=True, file_okay=False)] = Path(
+        "/out"
+    ),
     defaults_version: Annotated[str, typer.Option()] = "22.2.2.1",
-    emod3d_path: Annotated[Path, typer.Option(exists=True, readable=True, dir_okay=False)] = Path("/EMOD3D/tools/emod3d-mpi_v3.0.8"),
+    emod3d_path: Annotated[
+        Path, typer.Option(exists=True, readable=True, dir_okay=False)
+    ] = Path("/EMOD3D/tools/emod3d-mpi_v3.0.8"),
     emod3d_version: Annotated[str, typer.Option()] = "3.0.8",
 ):
     """Create EMOD3D parameter file from provided inputs.
@@ -297,3 +312,4 @@ def create_e3d_par(
             for key, value in e3d_par_values.items()
         )
     )
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/gcmt_to_realisation.py
+++ b/workflow/scripts/gcmt_to_realisation.py
@@ -41,6 +41,7 @@ from qcore import cli
 from qcore.uncertainties import distributions, mag_scaling
 from source_modelling import community_fault_model, sources
 from source_modelling.community_fault_model import NodalPlane
+from workflow import realisations
 from workflow.defaults import DefaultsVersion
 from workflow.realisations import (
     RealisationMetadata,
@@ -198,3 +199,4 @@ def gcmt_to_realisation(
     metadata.write_to_realisation(realisation_ffp)
     source_config.write_to_realisation(realisation_ffp)
     rupture_config.write_to_realisation(realisation_ffp)
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/generate_model_coordinates.py
+++ b/workflow/scripts/generate_model_coordinates.py
@@ -32,7 +32,7 @@ from typing import Annotated
 import typer
 
 from qcore import cli
-from workflow import log_utils
+from workflow import log_utils, realisations
 from workflow.realisations import DomainParameters
 
 app = typer.Typer()
@@ -41,12 +41,8 @@ app = typer.Typer()
 @cli.from_docstring(app)
 @log_utils.log_call()
 def generate_model_coordinates(
-    realisation_ffp: Annotated[
-        Path, typer.Argument(exists=True, readable=True)
-    ],
-    output_ffp: Annotated[
-        Path, typer.Argument(writable=True)
-    ],
+    realisation_ffp: Annotated[Path, typer.Argument(exists=True, readable=True)],
+    output_ffp: Annotated[Path, typer.Argument(writable=True)],
 ) -> None:
     """
     Generate model coordinate files for EMOD3D from a realisation JSON file.
@@ -121,3 +117,4 @@ def generate_model_coordinates(
             ]
         )
     )
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/generate_rupture_propagation.py
+++ b/workflow/scripts/generate_rupture_propagation.py
@@ -135,12 +135,8 @@ def generate_rupture_propagation(
         dict[str, float],
         typer.Argument(parser=rake_parser),
     ],
-    shypo: Annotated[
-        Optional[float], typer.Option(min=0, max=1)
-    ] = None,
-    dhypo: Annotated[
-        Optional[float], typer.Option(min=0, max=1)
-    ] = None,
+    shypo: Annotated[Optional[float], typer.Option(min=0, max=1)] = None,
+    dhypo: Annotated[Optional[float], typer.Option(min=0, max=1)] = None,
 ):
     """Generate a likely rupture propagation for a given set of sources.
 
@@ -188,6 +184,7 @@ def generate_rupture_propagation(
     )
 
     rupture_propagation_config.write_to_realisation(realisation_ffp)
+    realisations.append_log_entry(realisation_ffp)
 
 
 if __name__ == "__main__":

--- a/workflow/scripts/generate_station_coordinates.py
+++ b/workflow/scripts/generate_station_coordinates.py
@@ -36,7 +36,7 @@ import pandas as pd
 import typer
 
 from qcore import cli
-from workflow import log_utils
+from workflow import log_utils, realisations
 from workflow.realisations import DomainParameters
 
 app = typer.Typer()
@@ -139,3 +139,4 @@ def generate_fd_files(
             ),
             axis=1,
         )
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/generate_station_coordinates.py
+++ b/workflow/scripts/generate_station_coordinates.py
@@ -45,7 +45,7 @@ app = typer.Typer()
 @cli.from_docstring(app)
 @log_utils.log_call()
 def generate_fd_files(
-    realisations_ffp: Annotated[Path, typer.Argument(readable=True)],
+    realisation_ffp: Annotated[Path, typer.Argument(readable=True)],
     output_path: Annotated[Path, typer.Argument(file_okay=False, writable=True)],
     keep_dup_station: Annotated[bool, typer.Option()] = True,
     stat_file: Annotated[Path, typer.Option(readable=True, exists=True)] = Path(
@@ -56,7 +56,7 @@ def generate_fd_files(
 
     Parameters
     ----------
-    realisations_ffp : Path
+    realisation_ffp : Path
         Path to realisation json file.
     output_path : Path
         Output path for station files.
@@ -66,7 +66,7 @@ def generate_fd_files(
         The location of the station files.
     """
     output_path.mkdir(exist_ok=True)
-    domain_parameters = DomainParameters.read_from_realisation(realisations_ffp)
+    domain_parameters = DomainParameters.read_from_realisation(realisation_ffp)
 
     # where to save gridpoint and longlat station files
     gp_out = output_path / "stations.statcords"

--- a/workflow/scripts/generate_stoch.py
+++ b/workflow/scripts/generate_stoch.py
@@ -31,7 +31,7 @@ from typing import Annotated
 import typer
 
 from qcore import cli
-from workflow import log_utils
+from workflow import log_utils, realisations
 from workflow.realisations import HFConfig, RealisationMetadata, SourceConfig
 
 app = typer.Typer()
@@ -43,7 +43,9 @@ def generate_stoch(
     realisation_ffp: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
     srf_ffp: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
     stoch_ffp: Annotated[Path, typer.Argument(dir_okay=False)],
-    srf2stoch_path: Annotated[Path, typer.Option(exists=True)] = Path("/EMOD3D/tools/srf2stoch"),
+    srf2stoch_path: Annotated[Path, typer.Option(exists=True)] = Path(
+        "/EMOD3D/tools/srf2stoch"
+    ),
 ):
     """Generate a stoch file from an SRF file.
 
@@ -81,3 +83,4 @@ def generate_stoch(
             f"outfile={stoch_ffp}",
         ]
     )
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/generate_velocity_model.py
+++ b/workflow/scripts/generate_velocity_model.py
@@ -41,7 +41,7 @@ from typing import Annotated, Optional
 import typer
 
 from qcore import cli
-from workflow import log_utils
+from workflow import log_utils, realisations
 from workflow.realisations import (
     DomainParameters,
     RealisationMetadata,
@@ -126,10 +126,18 @@ def run_nzvm(
 @cli.from_docstring(app)
 @log_utils.log_call()
 def generate_velocity_model(
-    realisation_ffp: Annotated[Path, typer.Argument(readable=True, exists=True, dir_okay=False)],
-    velocity_model_output: Annotated[Path, typer.Argument(writable=True, file_okay=False, exists=False)],
-    velocity_model_bin_path: Annotated[Path, typer.Option(exists=True, readable=True)] = Path("/Velocity-Model/NZVM"),
-    work_directory: Annotated[Path, typer.Option(exists=False, writable=True, file_okay=False)] = Path("/out"),
+    realisation_ffp: Annotated[
+        Path, typer.Argument(readable=True, exists=True, dir_okay=False)
+    ],
+    velocity_model_output: Annotated[
+        Path, typer.Argument(writable=True, file_okay=False, exists=False)
+    ],
+    velocity_model_bin_path: Annotated[
+        Path, typer.Option(exists=True, readable=True)
+    ] = Path("/Velocity-Model/NZVM"),
+    work_directory: Annotated[
+        Path, typer.Option(exists=False, writable=True, file_okay=False)
+    ] = Path("/out"),
     num_threads: Annotated[Optional[int], typer.Option(min=1)] = None,
 ) -> None:
     """
@@ -177,3 +185,4 @@ def generate_velocity_model(
     shutil.copytree(
         velocity_model_intermediate_path / "Velocity_Model", velocity_model_output
     )
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/generate_velocity_model_parameters.py
+++ b/workflow/scripts/generate_velocity_model_parameters.py
@@ -45,7 +45,7 @@ from qcore.uncertainties import mag_scaling
 from source_modelling import sources
 from velocity_modelling import bounding_box
 from velocity_modelling.bounding_box import BoundingBox
-from workflow import log_utils
+from workflow import log_utils, realisations
 from workflow.realisations import (
     DomainParameters,
     RealisationMetadata,
@@ -494,3 +494,4 @@ def generate_velocity_model_parameters(
         dt=velocity_model_parameters.dt,
     )
     domain_parameters.write_to_realisation(realisation_ffp)
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/hf_sim.py
+++ b/workflow/scripts/hf_sim.py
@@ -45,7 +45,7 @@ import pandas as pd
 import typer
 
 from qcore import cli
-from workflow import log_utils, utils
+from workflow import log_utils, realisations, utils
 from workflow.realisations import (
     DomainParameters,
     HFConfig,
@@ -290,3 +290,4 @@ def run_hf(
                 waveforms_dset[i] = waveform
 
     stations.to_hdf(out_file, key="stations", mode="a")
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -42,7 +42,7 @@ import xarray as xr
 from IM import im_reader, ims
 from IM.im_calculation import IM
 from qcore import cli, coordinates
-from workflow import utils
+from workflow import realisations, utils
 from workflow.realisations import (
     BroadbandParameters,
     IntensityMeasureCalculationParameters,
@@ -225,3 +225,4 @@ def calculate_instensity_measures(
         dataset[im_name] = result
 
     im_reader.write_intensity_measures(dataset, output_path)
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/nshm2022_to_realisation.py
+++ b/workflow/scripts/nshm2022_to_realisation.py
@@ -46,6 +46,7 @@ from qcore import cli
 from qcore.uncertainties import distributions, mag_scaling
 from source_modelling import rupture_propagation
 from source_modelling.sources import Fault
+from workflow import realisations
 from workflow.defaults import DefaultsVersion
 from workflow.log_utils import log_call
 from workflow.realisations import (
@@ -121,13 +122,8 @@ class SamplingStrategy(StrEnum):
 @cli.from_docstring(app)
 @log_call()
 def generate_realisation(
-    nshmdb_path: Annotated[
-        Path, typer.Argument(exists=True, dir_okay=False)
-    ],
-    rupture_id: Annotated[
-        int,
-        typer.Argument()
-    ],
+    nshmdb_path: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
+    rupture_id: Annotated[int, typer.Argument()],
     realisation_ffp: Annotated[
         Path,
         typer.Argument(writable=True),
@@ -256,3 +252,4 @@ def generate_realisation(
     realisation_ffp.parent.mkdir(parents=True, exist_ok=True)
     for section in [source_config, rupture_propagation_config]:
         section.write_to_realisation(realisation_ffp)
+    realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/realisation_to_srf.py
+++ b/workflow/scripts/realisation_to_srf.py
@@ -55,7 +55,7 @@ from scipy.sparse import csr_array
 from qcore import cli, coordinates
 from source_modelling import gsf, rupture_propagation, srf
 from source_modelling.sources import IsSource
-from workflow import log_utils, utils
+from workflow import log_utils, realisations, utils
 from workflow.log_utils import log_call
 from workflow.realisations import (
     RealisationMetadata,
@@ -575,3 +575,4 @@ def generate_srf(
     srf_config.write_to_realisation(realisation_ffp)
 
     shutil.copyfile(work_directory / (srf_name + ".srf"), output_srf_filepath)
+    realisations.append_log_entry(realisation_ffp)


### PR DESCRIPTION
This PR adds a command log to the end of realisation json files. The command log keeps track of each transformation applied to a realisation so that you can reproduce the contents of the realisation file by re-running the commands. It is intended to answer questions like "What sampling strategy did we apply for the hypocentre here", or "did we override the dx value in the SRF to stoch file". The log trail is a json object with the following structure.

``` json
{
  "log_trail": {
    "log": [
      {
        "utility": "nshm2022-to-realisation",
        "version": "0.1.dev657+ge39e1ac.d19800101",
        "timestamp": "2025-04-17T12:01:17.399034",
        "args": [
          "/home/jake/nshmdb.db",
          "71072",
          "alpine_hope_1.json",
          "24.2.2.2",
          "--strategy",
          "maximising"
        ]
      }
    ]
  }
}
```

It **does not** replace the logging we do while we run a script, which is primarily to enable us to debug problems in broken scripts.