### PR TITLE
Remove references to `qcore.gmt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pyarrow
 pytest
 pyvis
 pyyaml
+pygmt_helper @ git+https://github.com/ucgmsim/pygmt_helper.git
 qcore @ git+https://github.com/ucgmsim/qcore.git
 requests
 schema

--- a/workflow/scripts/gcmt_auto_simulate.py
+++ b/workflow/scripts/gcmt_auto_simulate.py
@@ -40,7 +40,8 @@ import shapely
 import typer
 from shapely import Polygon
 
-from qcore import cli, coordinates, gmt
+from pygmt_helper import plotting
+from qcore import cli, coordinates
 
 app = typer.Typer()
 
@@ -53,7 +54,7 @@ def get_nz_outline_polygon() -> Polygon:
     Polygon
         The outline polygon of New Zealand.
     """
-    coastline_path = gmt.GMT_DATA.fetch("data/Paths/coastline/NZ.gmt")
+    coastline_path = plotting.GMT_DATA.fetch("data/Paths/coastline/NZ.gmt")
 
     gpd_df = gpd.read_file(coastline_path)
     island_polygons = [

--- a/workflow/scripts/generate_velocity_model_parameters.py
+++ b/workflow/scripts/generate_velocity_model_parameters.py
@@ -40,7 +40,8 @@ from shapely import Polygon
 
 from empirical.util import z_model_calculations
 from empirical.util.classdef import GMM, TectType
-from qcore import cli, coordinates, gmt
+from pygmt_helper import plotting
+from qcore import cli, coordinates
 from qcore.uncertainties import mag_scaling
 from source_modelling import sources
 from velocity_modelling import bounding_box
@@ -65,7 +66,7 @@ def get_nz_outline_polygon() -> Polygon:
     Polygon
         The outline polygon of New Zealand.
     """
-    coastline_path = gmt.GMT_DATA.fetch("data/Paths/coastline/NZ.gmt")
+    coastline_path = plotting.GMT_DATA.fetch("data/Paths/coastline/NZ.gmt")
 
     gpd_df = gpd.read_file(coastline_path)
     island_polygons = [


### PR DESCRIPTION
The `qcore.gmt` module no longer exists, so this changes the references to `GMT_DATA` I was using