### PR TITLE
Container fixes

### DIFF
--- a/docker/runner/runner.def
+++ b/docker/runner/runner.def
@@ -17,7 +17,7 @@ From: ubuntu:latest
                       ghostscript \
                       git \
                       gmt \
-                      gmt \
+                      libgmt-dev \
                       gmt-dcw \
                       gmt-gshhg \
                       graphicsmagick \

--- a/workflow/templates/hypocentre/im_calc.cylc
+++ b/workflow/templates/hypocentre/im_calc.cylc
@@ -1,3 +1,3 @@
 [[{{stage_node_identifier(stage)}}]]
-        script = apptainer exec -c --bind "$PWD:/out,$CYLC_WORKFLOW_SHARE_DIR/{{realisation_identifier(stage)}}:/share" {{container}} im-calc /share/realisation.json /share/realisation.bb /share/intensity_measures.parquet --ko-directory /mnt/hypo_scratch/ko_matrices
+        script = apptainer exec -c --bind "$PWD:/out,$CYLC_WORKFLOW_SHARE_DIR/{{realisation_identifier(stage)}}:/share,/mnt/hypo_scratch/ko_matrices:/ko_matrices" {{container}} im-calc /share/realisation.json /share/realisation.bb /share/intensity_measures.parquet --ko-directory /ko_matrices
         inherit = large_job

--- a/workflow/templates/nesi/im_calc.cylc
+++ b/workflow/templates/nesi/im_calc.cylc
@@ -1,5 +1,5 @@
 [[{{stage_node_identifier(stage)}}]]
-        script = apptainer exec -c --bind "$PWD:/out,$CYLC_WORKFLOW_SHARE_DIR/{{realisation_identifier(stage)}}:/share" {{container}} im-calc /share/realisation.json /share/realisation.bb /share/intensity_measures.parquet --num-processes 64 --psa-rotd-maximum-memory-allocation 40 --ko-directory /nesi/project/nesi00213/ko_matrices
+        script = apptainer exec -c --bind "$PWD:/out,$CYLC_WORKFLOW_SHARE_DIR/{{realisation_identifier(stage)}}:/share,/nesi/project/nesi00213/ko_matrices:/ko_matrices" {{container}} im-calc /share/realisation.json /share/realisation.bb /share/intensity_measures.h5 --num-processes 64 --psa-rotd-maximum-memory-allocation 40 --ko-directory /ko_matrices
         [[[directives]]]
                 --cpus-per-task = 64
                 --time = 01:00:00


### PR DESCRIPTION
This PR contains three fixes:

1. Builds libgmt-dev with the container so that GMT stages work.
2. Bind-mounts the ko matrix directory so that `im-calc` works
3. Saves the intensity measures to an `h5` extension rather than a `parquet` extension. The files have been hdf5 for a while that just wasn't updated.