### PR TITLE
Add container build action

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - pegasus
   workflow_dispatch:
 
 jobs:
@@ -42,4 +43,4 @@ jobs:
 
     - name: Upload container to Dropbox
       run: |
-        rclone copy $CONTAINER_NAME dropbox:apptainer-containers/
+        rclone copy $CONTAINER_NAME dropbox:/QuakeCoRE/Containers

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,45 @@
+name: Build, Test in Container, and Upload
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-test-upload:
+    runs-on: ubuntu-latest
+
+    env:
+      COMMIT_HASH: ${{ github.sha }}
+      CONTAINER_NAME: runner-${{ github.sha }}.sif
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y apptainer fuse-overlayfs squashfs-tools python3-pip
+        python3 -m pip install rclone
+
+    - name: Build Apptainer container
+      run: |
+        sudo apptainer build $CONTAINER_NAME docker/runner/runner.def
+
+    - name: Run pytest inside container
+      run: |
+        apptainer exec \
+          --bind $PWD:/mnt \
+          $CONTAINER_NAME \
+          bash -c "cd /mnt && pytest tests/"
+
+    - name: Configure rclone for Dropbox
+      run: |
+        mkdir -p ~/.config/rclone
+        echo "${{ secrets.RCLONE_CONFIG }}" > ~/.config/rclone/rclone.conf
+
+    - name: Upload container to Dropbox
+      run: |
+        rclone copy $CONTAINER_NAME dropbox:apptainer-containers/


### PR DESCRIPTION
Adds a container build action that automatically uploads containers to dropbox when:

1. A PR merges to main or pegasus, and
2. The tests pass.

This should simplify the deployment of fixes for researchers, we can just point them to a link they can download. 