### PR TITLE
fix: 400m bb flo

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -52,8 +52,14 @@ jobs:
 
     - name: Configure rclone for Dropbox
       run: |
-        mkdir -p ~/.config/rclone
-        echo "${{ secrets.RCLONE_CONFIG }}" > ~/.config/rclone/rclone.conf
+          mkdir -p ~/.config/rclone
+          cat <<EOF > ~/.config/rclone/rclone.conf
+          [dropbox]
+          type = dropbox
+          client_id =
+          client_secret =
+          token = '${ secrets.RCLONE_CONFIG }'
+          EOF
 
     - name: Upload container to Dropbox
       run: |

--- a/workflow/default_parameters/v24_2_2_4/defaults.yaml
+++ b/workflow/default_parameters/v24_2_2_4/defaults.yaml
@@ -533,7 +533,7 @@ hf_velocity_model_1d:
       Qp: 394.80
       Qs: 197.40
 bb:
-  flo: 0.5
+  flo: 0.25
   dt: 0.02
   fmidbot: 0.5
   fmin: 0.25


### PR DESCRIPTION
This PR corrects the default `bb flo` parameter for 400 m

[From Robin](https://uceqeng.slack.com/archives/C0C0QPGDR/p1747350409366909?thread_ts=1747284128.208649&cid=C0C0QPGDR), the `bb flo` should be:

 `flo = Vs,min/(5 * dx)`
 
 where 
 
 `Vs,min = 500 m/s` and `dx` is the grid spacing (100m, 200m, or 400m)
 
For `dx = 100, 200, 400`, `flo = 1.0, 0.5, 0.25`

So only the 400m defaults need to be updated in this PR