### PR TITLE
pass fault bottom instead of hypocentre to get_max_depth() function

### DIFF
--- a/workflow/scripts/generate_velocity_model_parameters.py
+++ b/workflow/scripts/generate_velocity_model_parameters.py
@@ -445,7 +445,7 @@ def generate_velocity_model_parameters(
     initial_fault = source_config.source_geometries[rupture_propagation.initial_fault]
     max_depth = get_max_depth(
         rupture_magnitude,
-        initial_fault.bottom_m / 1000,
+        initial_fault.planes[0].bottom_m / 1000,
     )
 
     # This polygon includes all the faults corners + a 2km buffer (which must be in the simulation domain).

--- a/workflow/scripts/generate_velocity_model_parameters.py
+++ b/workflow/scripts/generate_velocity_model_parameters.py
@@ -445,10 +445,7 @@ def generate_velocity_model_parameters(
     initial_fault = source_config.source_geometries[rupture_propagation.initial_fault]
     max_depth = get_max_depth(
         rupture_magnitude,
-        initial_fault.fault_coordinates_to_wgs_depth_coordinates(
-            rupture_propagation.hypocentre
-        )[2]
-        / 1000,
+        initial_fault.bottom_m / 1000,
     )
 
     # This polygon includes all the faults corners + a 2km buffer (which must be in the simulation domain).


### PR DESCRIPTION
This PR changes how `max_depth` is calculated. Now the `get_max_depth()` function is given the fault's bottom instead of hypocentre, making the `max_depth` lower