### PR TITLE
Makes workflow nz rounding consistent with C NZVM code

### DIFF
--- a/tests/test_realisation.py
+++ b/tests/test_realisation.py
@@ -73,8 +73,14 @@ def test_domain_parameters_properties() -> None:
         duration=60.0,
         dt=0.005,
     )
-    assert domain_parameters.nx == 1000
-    assert domain_parameters.ny == 1000
+
+    # If DomainParameters were to round before converting to int, it would give
+    # nx = 1000 and ny = 1000. However, for consistency with the
+    # C NZVM code, the calculated values are simply truncated to int, giving
+    # nx = 999 and ny = 999. nz = 400 with and without rounding for these inputs.
+
+    assert domain_parameters.nx == 999
+    assert domain_parameters.ny == 999
     assert domain_parameters.nz == 400
 
 

--- a/tests/test_realisation.py
+++ b/tests/test_realisation.py
@@ -74,13 +74,8 @@ def test_domain_parameters_properties() -> None:
         dt=0.005,
     )
 
-    # If DomainParameters were to round before converting to int, it would give
-    # nx = 1000 and ny = 1000. However, for consistency with the
-    # C NZVM code, the calculated values are simply truncated to int, giving
-    # nx = 999 and ny = 999. nz = 400 with and without rounding for these inputs.
-
-    assert domain_parameters.nx == 999
-    assert domain_parameters.ny == 999
+    assert domain_parameters.nx == 1000
+    assert domain_parameters.ny == 1000
     assert domain_parameters.nz == 400
 
 

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -445,19 +445,22 @@ class DomainParameters(RealisationConfiguration):
     @property
     def nx(self) -> int:  # numpydoc ignore=RT01
         """int: The number of x coordinate positions in the discretised domain."""
-        return int(np.round(self.domain.extent_x / self.resolution))
+        # The C NZVM code truncates (removes the decimal part) of the nx value,
+        # so we do the same for consistency
+        return int(self.domain.extent_x / self.resolution)
 
     @property
     def ny(self) -> int:  # numpydoc ignore=RT01
         """int: The number of y coordinate positions in the discretised domain."""
-        return int(np.round(self.domain.extent_y / self.resolution))
+        # The C NZVM code truncates (removes the decimal part) of the ny value,
+        # so we do the same for consistency
+        return int(self.domain.extent_y / self.resolution)
 
     @property
     def nz(self) -> int:  # numpydoc ignore=RT01
         """int: The number of z coordinate positions in the discretised domain."""
         # The C NZVM code truncates (removes the decimal part) of the nz value,
-        # so we do the same for consistency. The C NZVM code does round the nx and ny
-        # values, so it is unclear why the nz value is treated differently.
+        # so we do the same for consistency
         return int(self.depth / self.resolution)
 
     def to_dict(self) -> dict:

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -244,9 +244,7 @@ class Seeds(RealisationConfiguration):
     @classmethod
     def read_from_realisation_or_defaults(
         cls, realisation_ffp: Path, *args: list[Any]
-    ) -> (
-        Self
-    ):  # *args is to maintain compat with superclass (remove this and see the error in mypy).
+    ) -> Self:  # *args is to maintain compat with superclass (remove this and see the error in mypy).
         """Read seeds configuration from a realisation file or generate random seeds if not present.
 
         This method attempts to read the seeds configuration from the specified
@@ -457,7 +455,10 @@ class DomainParameters(RealisationConfiguration):
     @property
     def nz(self) -> int:  # numpydoc ignore=RT01
         """int: The number of z coordinate positions in the discretised domain."""
-        return int(np.round(self.depth / self.resolution))
+        # The C NZVM code truncates (removes the decimal part) of the nz value,
+        # so we do the same for consistency. The C NZVM code does round the nx and ny
+        # values, so it is unclear why the nz value is treated differently.
+        return int(self.depth / self.resolution)
 
     def to_dict(self) -> dict:
         """

--- a/workflow/realisations.py
+++ b/workflow/realisations.py
@@ -445,23 +445,26 @@ class DomainParameters(RealisationConfiguration):
     @property
     def nx(self) -> int:  # numpydoc ignore=RT01
         """int: The number of x coordinate positions in the discretised domain."""
-        # The C NZVM code truncates (removes the decimal part) of the nx value,
-        # so we do the same for consistency
-        return int(self.domain.extent_x / self.resolution)
+        # The C NZVM code always rounds 0.5 up to 1.0 but Python does not always
+        # round in the same way. So we manually replicate the C rounding behaviour
+        # here for consistency.
+        return int((self.domain.extent_x / self.resolution) + 0.5)
 
     @property
     def ny(self) -> int:  # numpydoc ignore=RT01
         """int: The number of y coordinate positions in the discretised domain."""
-        # The C NZVM code truncates (removes the decimal part) of the ny value,
-        # so we do the same for consistency
-        return int(self.domain.extent_y / self.resolution)
+        # The C NZVM code always rounds 0.5 up to 1.0 but Python does not always
+        # round in the same way. So we manually replicate the C rounding behaviour
+        # here for consistency.
+        return int((self.domain.extent_y / self.resolution) + 0.5)
 
     @property
     def nz(self) -> int:  # numpydoc ignore=RT01
         """int: The number of z coordinate positions in the discretised domain."""
-        # The C NZVM code truncates (removes the decimal part) of the nz value,
-        # so we do the same for consistency
-        return int(self.depth / self.resolution)
+        # The C NZVM code always rounds 0.5 up to 1.0 but Python does not always
+        # round in the same way. So we manually replicate the C rounding behaviour
+        # here for consistency.
+        return int((self.depth / self.resolution) + 0.5)
 
     def to_dict(self) -> dict:
         """


### PR DESCRIPTION
This PR makes the workflow round the number of z coordinate positions in the discretised domain (nz) in the same way as the C NZVM code, which just truncates the nz value