### PR TITLE
Misc HF, broadband and IM calc fixes

### DIFF
--- a/workflow/default_parameters/v24_2_2_1/defaults.yaml
+++ b/workflow/default_parameters/v24_2_2_1/defaults.yaml
@@ -74,7 +74,7 @@ hf:
   dt: 0.005
   t_sec: 0.0
   sdrop: 50.0
-  rayset: [1, 2]
+  rayset: [1]
   no_siteamp: false
   fmax: 10.0
   kappa: 0.045

--- a/workflow/default_parameters/v24_2_2_2/defaults.yaml
+++ b/workflow/default_parameters/v24_2_2_2/defaults.yaml
@@ -74,7 +74,7 @@ hf:
   dt: 0.01
   t_sec: 0.0
   sdrop: 50.0
-  rayset: [1, 2]
+  rayset: [1]
   no_siteamp: false
   fmax: 10.0
   kappa: 0.045

--- a/workflow/default_parameters/v24_2_2_4/defaults.yaml
+++ b/workflow/default_parameters/v24_2_2_4/defaults.yaml
@@ -74,7 +74,7 @@ hf:
   dt: 0.02
   t_sec: 0.0
   sdrop: 50.0
-  rayset: [1, 2]
+  rayset: [1]
   no_siteamp: false
   fmax: 10.0
   kappa: 0.045

--- a/workflow/scripts/bb_sim.py
+++ b/workflow/scripts/bb_sim.py
@@ -179,7 +179,7 @@ def combine_hf_and_lf(
         )
         bb_nt = temp_lf_padded.shape[1]
 
-        vs30_df["pga"] = temp_hf_padded.max(axis=1) * G
+        vs30_df["pga"] = np.abs(temp_hf_padded).max(axis=1) * G
 
         hf_amp_val = siteamp_models.cb_amp_multi(vs30_df)
         hf_amp_fas_vals = siteamp_models.cb2014_to_fas_amplification_factors(

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -28,6 +28,7 @@ See the output of `im-calc --help`.
 """
 
 import functools
+import typing
 from pathlib import Path
 from typing import Annotated, Optional
 
@@ -69,9 +70,8 @@ def calculate_instensity_measures(
     ko_directory: Annotated[
         Path | None, typer.Option(exists=True, file_okay=False)
     ] = None,
-    ims: Annotated[
-        list[IM] | None, typer.Option('-i', '--im')
-    ] = None
+    ims: Annotated[list[IM] | None, typer.Option("-i", "--im")] = None,
+    resume_from_checkpoint: Annotated[bool, typer.Option()] = True,
 ) -> None:
     """Calculate intensity measures for simulation data.
 
@@ -91,6 +91,8 @@ def calculate_instensity_measures(
         Directory containing the KO matrix files for FAS calculation. Not required for other IMs.
     ims : list of str
         Intensity measures to calculate. If not set, reads from the realisation file.
+    resume_from_checkpoint : bool
+        If set, check the output path and skip calculation for IMs already present.
     """
     ne.set_num_threads(utils.get_available_cores())
 
@@ -112,6 +114,19 @@ def calculate_instensity_measures(
         )
 
     intensity_measures = ims or intensity_measure_parameters.ims
+
+    if resume_from_checkpoint and output_path.exists():
+        try:
+            im_dataset = xr.open_dataset(output_path, engine="h5netcdf")
+            computed_ims = typing.cast(set[IM], set(im_dataset))
+            intensity_measures = [
+                im for im in intensity_measures if im not in computed_ims
+            ]
+        except Exception as e:
+            print(
+                f"Could not resume from checkpoint due to error reading dataset: {e}. Will compute full set of specified IMs."
+            )
+            pass
 
     if IM.FAS in intensity_measures and not ko_directory:
         raise ValueError(
@@ -232,6 +247,6 @@ def calculate_instensity_measures(
         elif isinstance(result, xr.DataArray):
             result = result.assign_coords(station=broadband.station)
         dataset[im_name] = result
+        im_reader.write_intensity_measures(dataset, output_path)
 
-    im_reader.write_intensity_measures(dataset, output_path)
     realisations.append_log_entry(realisation_ffp)

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -103,7 +103,7 @@ def calculate_instensity_measures(
 
     if not simulated_stations:
         broadband = broadband.where(
-            broadband.station.str.findall(r"^(\w{4})$"), drop=True
+            broadband.station.str.match(r"^(\w{4})$"), drop=True
         )
 
     intensity_measures = intensity_measure_parameters.ims

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -71,7 +71,6 @@ def calculate_instensity_measures(
         Path | None, typer.Option(exists=True, file_okay=False)
     ] = None,
     override_ims: Annotated[list[IM] | None, typer.Option("-i", "--im")] = None,
-    resume_from_checkpoint: Annotated[bool, typer.Option()] = True,
 ) -> None:
     """Calculate intensity measures for simulation data.
 
@@ -91,8 +90,6 @@ def calculate_instensity_measures(
         Directory containing the KO matrix files for FAS calculation. Not required for other IMs.
     override_ims : list of str
         Intensity measures to calculate. If not set, reads from the realisation file.
-    resume_from_checkpoint : bool
-        If set, check the output path and skip calculation for IMs already present.
     """
     ne.set_num_threads(utils.get_available_cores())
 
@@ -114,19 +111,6 @@ def calculate_instensity_measures(
         )
 
     intensity_measures = override_ims or intensity_measure_parameters.ims
-    checkpoint_dataset = None
-    if resume_from_checkpoint and output_path.exists():
-        try:
-            checkpoint_dataset = xr.open_dataset(output_path, engine="h5netcdf")
-            computed_ims = typing.cast(set[IM], set(im_dataset))
-            intensity_measures = [
-                im for im in intensity_measures if im not in computed_ims
-            ]
-        except Exception as e:
-            print(
-                f"Could not resume from checkpoint due to error reading dataset: {e}. Will compute full set of specified IMs."
-            )
-            pass
 
     if IM.FAS in intensity_measures and not ko_directory:
         raise ValueError(
@@ -217,23 +201,20 @@ def calculate_instensity_measures(
         / 1000
     )
 
-    if checkpoint_dataset is not None:
-        dataset = checkpoint_dataset
-    else:
-        dataset = xr.Dataset(
-            coords={
-                "station": ("station", broadband.station.values),
-                "component": (
-                    "component",
-                    ["000", "090", "ver", "geom", "rotd0", "rotd50", "rotd100"],
-                ),
-                "rrup": ("station", rrup),
-                "rjb": ("station", rjb),
-                "hyp": ("station", hyp),
-                "epi": ("station", epi),
-            },
-            attrs={"hypo_lat": hypocentre[0], "hypo_lon": hypocentre[1]},
-        )
+    dataset = xr.Dataset(
+        coords={
+            "station": ("station", broadband.station.values),
+            "component": (
+                "component",
+                ["000", "090", "ver", "geom", "rotd0", "rotd50", "rotd100"],
+            ),
+            "rrup": ("station", rrup),
+            "rjb": ("station", rjb),
+            "hyp": ("station", hyp),
+            "epi": ("station", epi),
+        },
+        attrs={"hypo_lat": hypocentre[0], "hypo_lon": hypocentre[1]},
+    )
 
     # Add each column of the DataFrame as a coordinate
     # TODO: Refactor IM Calculation to use waveforms in (component, station, time) format

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -114,10 +114,10 @@ def calculate_instensity_measures(
         )
 
     intensity_measures = override_ims or intensity_measure_parameters.ims
-
+    checkpoint_dataset = None
     if resume_from_checkpoint and output_path.exists():
         try:
-            im_dataset = xr.open_dataset(output_path, engine="h5netcdf")
+            checkpoint_dataset = xr.open_dataset(output_path, engine="h5netcdf")
             computed_ims = typing.cast(set[IM], set(im_dataset))
             intensity_measures = [
                 im for im in intensity_measures if im not in computed_ims
@@ -217,20 +217,23 @@ def calculate_instensity_measures(
         / 1000
     )
 
-    dataset = xr.Dataset(
-        coords={
-            "station": ("station", broadband.station.values),
-            "component": (
-                "component",
-                ["000", "090", "ver", "geom", "rotd0", "rotd50", "rotd100"],
-            ),
-            "rrup": ("station", rrup),
-            "rjb": ("station", rjb),
-            "hyp": ("station", hyp),
-            "epi": ("station", epi),
-        },
-        attrs={"hypo_lat": hypocentre[0], "hypo_lon": hypocentre[1]},
-    )
+    if checkpoint_dataset is not None:
+        dataset = checkpoint_dataset
+    else:
+        dataset = xr.Dataset(
+            coords={
+                "station": ("station", broadband.station.values),
+                "component": (
+                    "component",
+                    ["000", "090", "ver", "geom", "rotd0", "rotd50", "rotd100"],
+                ),
+                "rrup": ("station", rrup),
+                "rjb": ("station", rjb),
+                "hyp": ("station", hyp),
+                "epi": ("station", epi),
+            },
+            attrs={"hypo_lat": hypocentre[0], "hypo_lon": hypocentre[1]},
+        )
 
     # Add each column of the DataFrame as a coordinate
     # TODO: Refactor IM Calculation to use waveforms in (component, station, time) format

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -69,6 +69,9 @@ def calculate_instensity_measures(
     ko_directory: Annotated[
         Path | None, typer.Option(exists=True, file_okay=False)
     ] = None,
+    ims: Annotated[
+        list[IM] | None, typer.Option('-i', '--im')
+    ] = None
 ) -> None:
     """Calculate intensity measures for simulation data.
 
@@ -86,6 +89,8 @@ def calculate_instensity_measures(
         Maximum amount of memory allocated for rotated PSA calculation station buffer, in gigabytes.
     ko_directory : Path
         Directory containing the KO matrix files for FAS calculation. Not required for other IMs.
+    ims : list of str
+        Intensity measures to calculate. If not set, reads from the realisation file.
     """
     ne.set_num_threads(utils.get_available_cores())
 
@@ -106,7 +111,7 @@ def calculate_instensity_measures(
             broadband.station.str.match(r"^(\w{4})$"), drop=True
         )
 
-    intensity_measures = intensity_measure_parameters.ims
+    intensity_measures = ims or intensity_measure_parameters.ims
 
     if IM.FAS in intensity_measures and not ko_directory:
         raise ValueError(

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -70,7 +70,7 @@ def calculate_instensity_measures(
     ko_directory: Annotated[
         Path | None, typer.Option(exists=True, file_okay=False)
     ] = None,
-    ims: Annotated[list[IM] | None, typer.Option("-i", "--im")] = None,
+    override_ims: Annotated[list[IM] | None, typer.Option("-i", "--im")] = None,
     resume_from_checkpoint: Annotated[bool, typer.Option()] = True,
 ) -> None:
     """Calculate intensity measures for simulation data.
@@ -89,7 +89,7 @@ def calculate_instensity_measures(
         Maximum amount of memory allocated for rotated PSA calculation station buffer, in gigabytes.
     ko_directory : Path
         Directory containing the KO matrix files for FAS calculation. Not required for other IMs.
-    ims : list of str
+    override_ims : list of str
         Intensity measures to calculate. If not set, reads from the realisation file.
     resume_from_checkpoint : bool
         If set, check the output path and skip calculation for IMs already present.
@@ -113,7 +113,7 @@ def calculate_instensity_measures(
             broadband.station.str.match(r"^(\w{4})$"), drop=True
         )
 
-    intensity_measures = ims or intensity_measure_parameters.ims
+    intensity_measures = override_ims or intensity_measure_parameters.ims
 
     if resume_from_checkpoint and output_path.exists():
         try:

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -28,7 +28,6 @@ See the output of `im-calc --help`.
 """
 
 import functools
-import typing
 from pathlib import Path
 from typing import Annotated, Optional
 


### PR DESCRIPTION
In no particular order, 

- IM calc must use match instead of findall for simulated stations now.
- Broadband amplification is correctly calculated from absmax instead of max.
- IM calculation now saves after each IM computed instead of just the end.
- Use rayset `[1]`, which is a single direct ray and no moho reflection. 