### PR TITLE
Fix off-by-one error in high-frequency `nt` calculation

### DIFF
--- a/workflow/scripts/hf_sim.py
+++ b/workflow/scripts/hf_sim.py
@@ -307,7 +307,7 @@ def run_hf(
     stations["seed"] = np.int32(seeds.hf_seed) ^ station_hashes
     velocity_model_path = work_directory / "velocity_model"
     velocity_model.write_velocity_model(velocity_model_path)
-    nt = int(domain_parameters.duration / hf_config.dt)
+    nt = int(domain_parameters.duration / hf_config.dt + 0.5)
     waveform = np.empty((3, len(stations), nt), dtype=np.float32)
 
     hf_input_template = build_hf_input(

--- a/workflow/scripts/hf_sim.py
+++ b/workflow/scripts/hf_sim.py
@@ -306,7 +306,7 @@ def run_hf(
     stations["seed"] = np.int32(seeds.hf_seed) ^ station_hashes
     velocity_model_path = work_directory / "velocity_model"
     velocity_model.write_velocity_model(velocity_model_path)
-    nt = int(np.float32(domain_parameters.duration) / np.float32(hf_config.dt))
+    nt = int(np.float32(domain_parameters.duration) / np.float32(hf_config.dt))  # Match Fortran's single-precision for consistent nt calculation
     waveform = np.empty((3, len(stations), nt), dtype=np.float32)
 
     hf_input_template = build_hf_input(

--- a/workflow/scripts/hf_sim.py
+++ b/workflow/scripts/hf_sim.py
@@ -307,7 +307,7 @@ def run_hf(
     stations["seed"] = np.int32(seeds.hf_seed) ^ station_hashes
     velocity_model_path = work_directory / "velocity_model"
     velocity_model.write_velocity_model(velocity_model_path)
-    nt = int(domain_parameters.duration / hf_config.dt)
+    nt = int(np.float32(domain_parameters.duration) / np.float32(hf_config.dt))
     waveform = np.empty((3, len(stations), nt), dtype=np.float32)
 
     hf_input_template = build_hf_input(


### PR DESCRIPTION
When calculating `nt` in the Python code, we calculate it as follows:
``` python
nt = int(domain_parameters.duration / dt)
```
Fortran calculates the `nt` value as follows
``` fortran
nt = int(duration / dt)
```
In principle, these are the same. And yet, if `duration = 55.41` and `dt = 0.005` on Python you'll get the answer `11081` and on Fortran `11082`. The truncation behaviour of `int` is the same in Fortran and Python, so what gives? Turns out, it's because the Python calculation is happening with 64-bit floating point values while the Fortran calculation uses 32-bit floating point values. This PR aligns the calculations by casting to 32-bit values first and then calculating the division.