### PR TITLE
Add merge-ts HDF5 output

### DIFF
--- a/workflow/scripts/merge_ts.py
+++ b/workflow/scripts/merge_ts.py
@@ -30,14 +30,16 @@ import os
 from pathlib import Path
 from typing import Annotated
 
-import typer
+import numpy as np
 import tqdm
+import typer
 import xarray as xr
 
-from qcore import cli, xyts, coordinates
+from qcore import cli, coordinates, xyts
 from workflow.scripts import merge_ts_loop
 
 app = typer.Typer()
+
 
 def merge_ts_xyts(
     component_xyts_directory: Annotated[
@@ -54,7 +56,7 @@ def merge_ts_xyts(
         typer.Argument(dir_okay=False, writable=True),
     ],
     glob_pattern: str = "*xyts-*.e3d",
-):
+) -> None:
     """Merge XYTS files.
 
     Parameters
@@ -153,8 +155,8 @@ def merge_ts_hdf5(
         typer.Argument(dir_okay=False, writable=True),
     ],
     glob_pattern: str = "*xyts-*.e3d",
-    complevel: int = 4
-):
+    complevel: int = 4,
+) -> None:
     """Merge XYTS files.
 
     Parameters
@@ -188,25 +190,20 @@ def merge_ts_hdf5(
     xyts_proc_header_size = 72
 
     waveform_data = np.zeros((nt, ny, nx), dtype=np.uint16)
-    for xyts_file in tqdm.tqdm(component_xyts_files, units='files'):
+    for xyts_file in tqdm.tqdm(component_xyts_files, units="files"):
         x0 = xyts_file.x0
         y0 = xyts_file.y0
         x1 = x0 + xyts_file.local_nx
         y1 = y0 + xyts_file.local_ny
-        data = np.fromfile(xyts_file.xyts_path, dtype=np.float32, offset=xyts_proc_header_size).reshape(
-            (nt, components, xyts_file.local_ny, xyts_file.local_nx)
-        )
-        magnitude = np.linalg.norm(
-            data,
-            axis=1
-        ) / 0.1
-        np.rint(
-            magnitude,
-            out=waveform_data[:, y0:y1, x0:x1],
-            dtype=np.uint16
-        )
+        data = np.fromfile(
+            xyts_file.xyts_path, dtype=np.float32, offset=xyts_proc_header_size
+        ).reshape((nt, components, xyts_file.local_ny, xyts_file.local_nx))
+        magnitude = np.linalg.norm(data, axis=1) / 0.1
+        np.rint(magnitude, out=waveform_data[:, y0:y1, x0:x1], dtype=np.uint16)
 
-    proj = coordinates.SphericalProjection(mlon=top_left.mlon, mlat=top_left.mlat, mrot=top_left.mrot)
+    proj = coordinates.SphericalProjection(
+        mlon=top_left.mlon, mlat=top_left.mlat, mrot=top_left.mrot
+    )
     dx = top_left.hh
     dt = top_left.dt
     y, x = np.meshgrid(np.arange(ny), np.arange(nx))
@@ -214,43 +211,48 @@ def merge_ts_hdf5(
     time = np.arange(nt) * dt
     dset = xr.Dataset(
         {
-            'waveform': (('time', 'y', 'x'), waveform_data),
+            "waveform": (("time", "y", "x"), waveform_data),
         },
         coords={
-            'time': ('time', time),
-            'y': ('y', np.arange(ny)),
-            'x': ('x', np.arange(nx)),
-            'latitude': (('y', 'x'), lat),
-            'longitude': (('y', 'x'), lon),
+            "time": ("time", time),
+            "y": ("y", np.arange(ny)),
+            "x": ("x", np.arange(nx)),
+            "latitude": (("y", "x"), lat),
+            "longitude": (("y", "x"), lon),
         },
-        attrs = {
-            'dx': dx,
-            'dy': dx,
-            'dt': dt,
-            'mlon': top_left.mlon,
-            'mlat': top_left.mlat,
-            'mrot': top_left.mrot
+        attrs={
+            "dx": dx,
+            "dy": dx,
+            "dt": dt,
+            "mlon": top_left.mlon,
+            "mlat": top_left.mlat,
+            "mrot": top_left.mrot,
         },
     )
 
-    dset['waveform'].attrs.update({
-        'scale_factor': 0.1,
-        'add_offset': 0.0,
-        'units': 'cm/s',
-        '_FillValue': -9999,
-    })
+    dset["waveform"].attrs.update(
+        {
+            "scale_factor": 0.1,
+            "add_offset": 0.0,
+            "units": "cm/s",
+            "_FillValue": -9999,
+        }
+    )
 
     dset.to_netcdf(
         output,
-        engine='h5netcdf',
-        encoding={'waveform': {
-            'dtype': 'int16',
-            'compression': 'zlib',
-            'complevel': complevel,
-            'shuffle': True,
-            '_FillValue': -9999,
-        }},
+        engine="h5netcdf",
+        encoding={
+            "waveform": {
+                "dtype": "int16",
+                "compression": "zlib",
+                "complevel": complevel,
+                "shuffle": True,
+                "_FillValue": -9999,
+            }
+        },
     )
+
 
 @cli.from_docstring(app)
 def merge_ts(
@@ -269,7 +271,7 @@ def merge_ts(
     ],
     glob_pattern: str = "*xyts-*.e3d",
     hdf5: bool = True,
-    complevel: int = 4
+    complevel: int = 4,
 ) -> None:
     """Merge XYTS files.
 

--- a/workflow/scripts/merge_ts.py
+++ b/workflow/scripts/merge_ts.py
@@ -273,7 +273,6 @@ def merge_ts(
         typer.Argument(dir_okay=False, writable=True),
     ],
     glob_pattern: str = "*xyts-*.e3d",
-    complevel: int = 4,
 ) -> None:
     """Merge XYTS files.
 
@@ -285,12 +284,5 @@ def merge_ts(
         The output xyts file.
     glob_pattern : str, optional
         Set a custom glob pattern for merging the xyts files, by default "*xyts-*.e3d".
-    hdf5 : bool, optional
-        If set, save output as a highly compressed HDF5 file. Defaults
-        to True.
-    complevel : int, optional
-        Set the compression level for the output HDF5 file. Range
-        between 1-9 (9 being the highest level of compression).
-        Defaults to 4.
     """
     merge_ts_xyts(component_xyts_directory, output, glob_pattern)

--- a/workflow/scripts/merge_ts.py
+++ b/workflow/scripts/merge_ts.py
@@ -275,7 +275,6 @@ def merge_ts(
         typer.Argument(dir_okay=False, writable=True),
     ],
     glob_pattern: str = "*xyts-*.e3d",
-    hdf5: bool = True,
     complevel: int = 4,
 ) -> None:
     """Merge XYTS files.
@@ -296,7 +295,4 @@ def merge_ts(
         between 1-9 (9 being the highest level of compression).
         Defaults to 4.
     """
-    if hdf5:
-        merge_ts_hdf5(component_xyts_directory, output, glob_pattern, complevel)
-    else:
-        merge_ts_xyts(component_xyts_directory, output, glob_pattern)
+    merge_ts_xyts(component_xyts_directory, output, glob_pattern)

--- a/workflow/scripts/merge_ts.py
+++ b/workflow/scripts/merge_ts.py
@@ -31,15 +31,15 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+import tqdm
+import xarray as xr
 
-from qcore import cli, xyts
+from qcore import cli, xyts, coordinates
 from workflow.scripts import merge_ts_loop
 
 app = typer.Typer()
 
-
-@cli.from_docstring(app)
-def merge_ts(
+def merge_ts_xyts(
     component_xyts_directory: Annotated[
         Path,
         typer.Argument(
@@ -53,8 +53,8 @@ def merge_ts(
         Path,
         typer.Argument(dir_okay=False, writable=True),
     ],
-    glob_pattern: Annotated[str, typer.Option()] = "*xyts-*.e3d",
-) -> None:
+    glob_pattern: str = "*xyts-*.e3d",
+):
     """Merge XYTS files.
 
     Parameters
@@ -65,6 +65,8 @@ def merge_ts(
         The output xyts file.
     glob_pattern : str, optional
         Set a custom glob pattern for merging the xyts files, by default "*xyts-*.e3d".
+    hdf5 : bool, optional
+        If set, save output as a highly compressed HDF5 file.
     """
     component_xyts_files = sorted(
         [
@@ -134,3 +136,160 @@ def merge_ts(
         os.close(xyts_file_descriptor)
 
     os.close(merged_fd)
+
+
+def merge_ts_hdf5(
+    component_xyts_directory: Annotated[
+        Path,
+        typer.Argument(
+            dir_okay=True,
+            file_okay=False,
+            exists=True,
+            readable=True,
+        ),
+    ],
+    output: Annotated[
+        Path,
+        typer.Argument(dir_okay=False, writable=True),
+    ],
+    glob_pattern: str = "*xyts-*.e3d",
+    complevel: int = 4
+):
+    """Merge XYTS files.
+
+    Parameters
+    ----------
+    component_xyts_directory : Path
+        The input xyts directory containing files to merge.
+    output : Path
+        The output xyts file.
+    glob_pattern : str, optional
+        Set a custom glob pattern for merging the xyts files, by default "*xyts-*.e3d".
+    complevel : int, optional
+        Set the compression level for the output HDF5 file. Range
+        between 1-9 (9 being the highest level of compression).
+        Defaults to 4.
+    """
+    component_xyts_files = sorted(
+        [
+            xyts.XYTSFile(
+                xyts_file_path, proc_local_file=True, meta_only=True, round_dt=False
+            )
+            for xyts_file_path in component_xyts_directory.glob(glob_pattern)
+        ],
+        key=lambda xyts_file: (xyts_file.y0, xyts_file.x0),
+    )
+    top_left = component_xyts_files[0]
+    nt = top_left.nt
+    nx = top_left.nx
+    ny = top_left.ny
+    components = 3
+
+    xyts_proc_header_size = 72
+
+    waveform_data = np.zeros((nt, ny, nx), dtype=np.uint16)
+    for xyts_file in tqdm.tqdm(component_xyts_files, units='files'):
+        x0 = xyts_file.x0
+        y0 = xyts_file.y0
+        x1 = x0 + xyts_file.local_nx
+        y1 = y0 + xyts_file.local_ny
+        data = np.fromfile(xyts_file.xyts_path, dtype=np.float32, offset=xyts_proc_header_size).reshape(
+            (nt, components, xyts_file.local_ny, xyts_file.local_nx)
+        )
+        magnitude = np.linalg.norm(
+            data,
+            axis=1
+        ) / 0.1
+        np.rint(
+            magnitude,
+            out=waveform_data[:, y0:y1, x0:x1],
+            dtype=np.uint16
+        )
+
+    proj = coordinates.SphericalProjection(mlon=top_left.mlon, mlat=top_left.mlat, mrot=top_left.mrot)
+    dx = top_left.hh
+    dt = top_left.dt
+    y, x = np.meshgrid(np.arange(ny), np.arange(nx))
+    lat, lon = proj.inverse(x.flatten(), y.flatten()).T
+    time = np.arange(nt) * dt
+    dset = xr.Dataset(
+        {
+            'waveform': (('time', 'y', 'x'), waveform_data),
+        },
+        coords={
+            'time': ('time', time),
+            'y': ('y', np.arange(ny)),
+            'x': ('x', np.arange(nx)),
+            'latitude': (('y', 'x'), lat),
+            'longitude': (('y', 'x'), lon),
+        },
+        attrs = {
+            'dx': dx,
+            'dy': dx,
+            'dt': dt,
+            'mlon': top_left.mlon,
+            'mlat': top_left.mlat,
+            'mrot': top_left.mrot
+        },
+    )
+
+    dset['waveform'].attrs.update({
+        'scale_factor': 0.1,
+        'add_offset': 0.0,
+        'units': 'cm/s',
+        '_FillValue': -9999,
+    })
+
+    dset.to_netcdf(
+        output,
+        engine='h5netcdf',
+        encoding={'waveform': {
+            'dtype': 'int16',
+            'compression': 'zlib',
+            'complevel': complevel,
+            'shuffle': True,
+            '_FillValue': -9999,
+        }},
+    )
+
+@cli.from_docstring(app)
+def merge_ts(
+    component_xyts_directory: Annotated[
+        Path,
+        typer.Argument(
+            dir_okay=True,
+            file_okay=False,
+            exists=True,
+            readable=True,
+        ),
+    ],
+    output: Annotated[
+        Path,
+        typer.Argument(dir_okay=False, writable=True),
+    ],
+    glob_pattern: str = "*xyts-*.e3d",
+    hdf5: bool = True,
+    complevel: int = 4
+) -> None:
+    """Merge XYTS files.
+
+    Parameters
+    ----------
+    component_xyts_directory : Path
+        The input xyts directory containing files to merge.
+    output : Path
+        The output xyts file.
+    glob_pattern : str, optional
+        Set a custom glob pattern for merging the xyts files, by default "*xyts-*.e3d".
+    hdf5 : bool, optional
+        If set, save output as a highly compressed HDF5 file. Defaults
+        to True.
+    complevel : int, optional
+        Set the compression level for the output HDF5 file. Range
+        between 1-9 (9 being the highest level of compression).
+        Defaults to 4.
+    """
+    if hdf5:
+        merge_ts_hdf5(component_xyts_directory, output, glob_pattern, complevel)
+    else:
+        merge_ts_xyts(component_xyts_directory, output, glob_pattern)

--- a/workflow/scripts/merge_ts.py
+++ b/workflow/scripts/merge_ts.py
@@ -67,8 +67,6 @@ def merge_ts_xyts(
         The output xyts file.
     glob_pattern : str, optional
         Set a custom glob pattern for merging the xyts files, by default "*xyts-*.e3d".
-    hdf5 : bool, optional
-        If set, save output as a highly compressed HDF5 file.
     """
     component_xyts_files = sorted(
         [

--- a/workflow/scripts/merge_ts.py
+++ b/workflow/scripts/merge_ts.py
@@ -140,6 +140,7 @@ def merge_ts_xyts(
     os.close(merged_fd)
 
 
+@cli.from_docstring(app, name="hdf5")
 def merge_ts_hdf5(
     component_xyts_directory: Annotated[
         Path,
@@ -189,8 +190,8 @@ def merge_ts_hdf5(
 
     xyts_proc_header_size = 72
 
-    waveform_data = np.zeros((nt, ny, nx), dtype=np.uint16)
-    for xyts_file in tqdm.tqdm(component_xyts_files, units="files"):
+    waveform_data = np.empty((nt, ny, nx), dtype=np.uint16)
+    for xyts_file in tqdm.tqdm(component_xyts_files, unit="files"):
         x0 = xyts_file.x0
         y0 = xyts_file.y0
         x1 = x0 + xyts_file.local_nx
@@ -199,15 +200,20 @@ def merge_ts_hdf5(
             xyts_file.xyts_path, dtype=np.float32, offset=xyts_proc_header_size
         ).reshape((nt, components, xyts_file.local_ny, xyts_file.local_nx))
         magnitude = np.linalg.norm(data, axis=1) / 0.1
-        np.rint(magnitude, out=waveform_data[:, y0:y1, x0:x1], dtype=np.uint16)
+        np.round(magnitude, out=magnitude)
+        waveform_data[:, y0:y1, x0:x1] = magnitude.astype(np.uint16)
 
     proj = coordinates.SphericalProjection(
         mlon=top_left.mlon, mlat=top_left.mlat, mrot=top_left.mrot
     )
     dx = top_left.hh
     dt = top_left.dt
-    y, x = np.meshgrid(np.arange(ny), np.arange(nx))
+    y, x = np.meshgrid(
+        np.arange(ny, dtype=np.float64), np.arange(nx, dtype=np.float64), indexing="ij"
+    )
     lat, lon = proj.inverse(x.flatten(), y.flatten()).T
+    lat = lat.reshape(y.shape)
+    lon = lon.reshape(y.shape)
     time = np.arange(nt) * dt
     dset = xr.Dataset(
         {
@@ -248,13 +254,12 @@ def merge_ts_hdf5(
                 "compression": "zlib",
                 "complevel": complevel,
                 "shuffle": True,
-                "_FillValue": -9999,
             }
         },
     )
 
 
-@cli.from_docstring(app)
+@cli.from_docstring(app, name="xyts")
 def merge_ts(
     component_xyts_directory: Annotated[
         Path,


### PR DESCRIPTION
The current `merge-ts` stage merges all the xyts files as a big 32-bit floating point array. This is undesirable for a few reasons:

1. No compression. Even though we know that the XYTS files are largely sparse across the domain the naive format includes no mechanism for compression.
2. Full 32-bit precision. This is quite unnecessary for the application of these files (visualisation and sanity checking only). Could a keen-eyed youtube viewer notice the difference between ground motion of  `25.01` cm/s and `25.01005` cm/s? Maybe, but I doubt it. 
3. It saves the x, y, and z components when we only ever visualise magnitude $\sqrt{x^2 + y^2 + z^2}$.
4. Because of the above, the file sizes are huge. Often, this means we don't archive XYTS outputs. Which is a shame because it limits both validation and visualisation of old simulations. 
5. It is yet another "proprietary" file format that we have to maintain infrastructure for. 

This PR addresses the above concerns by adding an option to save xyts.e3d files as a compressed HDF5 file with 16-bit integer quantised outputs. Ground motion in these files is accurate to `0.1` cm/s. Chunk-based compression and shuffling is enabled to further reduce the size of the files. The results can be quite dramatic, here is a dummy simulation I downloaded from RCH with nearly 1GB of xyts outputs (about as small as they get really). 
```bash
~/tmp 
❯ du -h OutBin --exclude='*seis*' 
719M    OutBin
```

Ordinarily, we wouldn't generate an XYTS file for such simulations. But the new code can do this very efficiently

```bash
$ merge-ts hdf5 OutBin test.h5
100%|██████████████████████████████████████████████████████████████████████████████████████| 80/80 [00:00<00:00, 154.38files/s]
$ ls -alh test.h5
.rw-r--r--  4.8M jake 23 Oct 15:35  test.h5
``` 

So we managed to compress 719Mb of data into 4.4Mb of XYTS data, a 100x saving for functionally the same information. Moreover, the files contain far more information. Notably, it uses the spherical projection code to show the lat/lon values of the coordinates.

```python
xr.open_dataset('test.h5')
/home/jake/src/workflow/.venv/lib/python3.13/site-packages/xarray/backends/plugins.py:109: RuntimeWarning: Engine 'gmt' loading failed:
Error loading GMT shared library at 'libgmt.so'.
libgmt.so: cannot open shared object file: No such file or directory
  external_backend_entrypoints = backends_dict_from_pkg(entrypoints_unique)
<xarray.Dataset> Size: 504MB
Dimensions:    (time: 649, y: 265, x: 365)
Coordinates:
  * time       (time) float64 5kB 0.0 0.1 0.2 0.3 0.4 ... 64.5 64.6 64.7 64.8
  * y          (y) int64 2kB 0 1 2 3 4 5 6 7 ... 257 258 259 260 261 262 263 264
  * x          (x) int64 3kB 0 1 2 3 4 5 6 7 ... 357 358 359 360 361 362 363 364
    latitude   (y, x) float64 774kB ...
    longitude  (y, x) float64 774kB ...
Data variables:
    waveform   (time, y, x) float64 502MB ...
Attributes:
    dx:       0.1
    dy:       0.1
    dt:       0.099999994
    mlon:     174.03157
    mlat:     -41.540768
    mrot:     325.42987
```

This HDF5 format will power a new GPU accelerated `plot-ts` to rapidly visualise simulations. There, the int16 representation also means that the memory efficiency of this code is considerably faster. 