### PR TITLE
bb-sim and im-calc use Resolution dt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest"]
 types = ["pandas-stubs", "types-geopandas", "types-requests", "scipy-stubs"]
-dev = ["ruff", "deptry", "ty"]
+dev = ["ruff", "deptry", "ty", "numpydoc"]
 
 [tool.deptry]
 pep621_dev_dependency_groups = ["test", "dev"]

--- a/workflow/scripts/bb_sim.py
+++ b/workflow/scripts/bb_sim.py
@@ -49,6 +49,7 @@ from workflow import log_utils, realisations
 from workflow.realisations import (
     BroadbandParameters,
     RealisationMetadata,
+    Resolution,
 )
 
 app = typer.Typer()
@@ -144,7 +145,10 @@ def combine_hf_and_lf(
     broadband_config = BroadbandParameters.read_from_realisation_or_defaults(
         realisation_ffp, metadata.defaults_version
     )
-    bb_dt = broadband_config.dt
+    resolution = Resolution.read_from_realisation_or_defaults(
+        realisation_ffp, metadata.defaults_version
+    )
+    bb_dt = resolution.dt
 
     # load data stores
     lf = xr.open_dataset(low_frequency_waveform_file)
@@ -186,16 +190,18 @@ def combine_hf_and_lf(
         assert isinstance(vs30_df, pd.DataFrame)
         hf_amp_val = siteamp_models.cb_amp_multi(vs30_df)
         hf_amp_fas_vals = siteamp_models.cb2014_to_fas_amplification_factors(
-            hf_amp_val, bb_dt, bb_nt
+            hf_amp_val,
+            bb_dt,
+            bb_nt,
         )
         hf_waveform_amped = timeseries.ampdeamp(
             temp_hf_padded, hf_amp_fas_vals, amplify=True
         )
         hf_filtered = timeseries.bwfilter(
-            hf_waveform_amped, bb_dt, 1.0, timeseries.Band.HIGHPASS
+            hf_waveform_amped, bb_dt, broadband_config.flo, timeseries.Band.HIGHPASS
         )
         lf_filtered = timeseries.bwfilter(
-            temp_lf_padded, bb_dt, 1.0, timeseries.Band.LOWPASS
+            temp_lf_padded, bb_dt, broadband_config.flo, timeseries.Band.LOWPASS
         )
         bb_waveforms.append((hf_filtered + lf_filtered) * G)
 

--- a/workflow/scripts/generate_station_coordinates.py
+++ b/workflow/scripts/generate_station_coordinates.py
@@ -81,7 +81,9 @@ def generate_fd_files(
         names=["lon", "lat", "name"],  # type: ignore[invalid-argument-type]
     )
 
-    x, y = proj(lat=stations["lat"].values, lon=stations["lon"].values).T
+    x, y = proj(
+        lat=stations["lat"].to_numpy(float), lon=stations["lon"].to_numpy(float)
+    ).T
 
     cx = nx // 2 * domain_parameters.resolution
     cy = ny // 2 * domain_parameters.resolution

--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -43,9 +43,9 @@ from IM.im_calculation import IM
 from qcore import cli, coordinates
 from workflow import realisations, utils
 from workflow.realisations import (
-    BroadbandParameters,
     IntensityMeasureCalculationParameters,
     RealisationMetadata,
+    Resolution,
     RupturePropagationConfig,
     SourceConfig,
 )
@@ -93,7 +93,9 @@ def calculate_instensity_measures(
     ne.set_num_threads(utils.get_available_cores())
 
     metadata = RealisationMetadata.read_from_realisation(realisation_ffp)
-    broadband_parameters = BroadbandParameters.read_from_realisation(realisation_ffp)
+    resolution = Resolution.read_from_realisation_or_defaults(
+        realisation_ffp, metadata.defaults_version
+    )
     intensity_measure_parameters = (
         IntensityMeasureCalculationParameters.read_from_realisation_or_defaults(
             realisation_ffp, metadata.defaults_version
@@ -116,29 +118,27 @@ def calculate_instensity_measures(
             "FAS calculation requires KO directory. Please provide a valid KO directory."
         )
 
-    nyquist_frequency = 1 / (2 * broadband_parameters.dt)
+    nyquist_frequency = 1 / (2 * resolution.dt)
 
     im_function_map = {
         IM.PGA: ims.peak_ground_acceleration,
-        IM.PGV: functools.partial(ims.peak_ground_velocity, dt=broadband_parameters.dt),
-        IM.CAV: functools.partial(
-            ims.cumulative_absolute_velocity, dt=broadband_parameters.dt
-        ),
-        IM.AI: functools.partial(ims.arias_intensity, dt=broadband_parameters.dt),
+        IM.PGV: functools.partial(ims.peak_ground_velocity, dt=resolution.dt),
+        IM.CAV: functools.partial(ims.cumulative_absolute_velocity, dt=resolution.dt),
+        IM.AI: functools.partial(ims.arias_intensity, dt=resolution.dt),
         IM.Ds575: functools.partial(
             ims.ds575,
-            dt=broadband_parameters.dt,
+            dt=resolution.dt,
         ),
         IM.Ds595: functools.partial(
             ims.ds595,
-            dt=broadband_parameters.dt,
+            dt=resolution.dt,
         ),
         IM.pSA: functools.partial(
             ims.pseudo_spectral_acceleration,
             periods=np.array(
                 intensity_measure_parameters.valid_periods, dtype=np.float32
             ),
-            dt=broadband_parameters.dt,
+            dt=resolution.dt,
             psa_rotd_maximum_memory_allocation=psa_rotd_maximum_memory_allocation * 1e9
             if psa_rotd_maximum_memory_allocation
             else None,
@@ -146,7 +146,7 @@ def calculate_instensity_measures(
         ),
         IM.FAS: functools.partial(
             ims.fourier_amplitude_spectra,
-            dt=broadband_parameters.dt,
+            dt=resolution.dt,
             freqs=intensity_measure_parameters.fas_frequencies[
                 intensity_measure_parameters.fas_frequencies <= nyquist_frequency
             ],


### PR DESCRIPTION
Quick patch that fixes a small bug in #75 where the `dt` changes weren't carried through `im_calc` and `bb_sim` due to the type checker not picking up that these values had changed. Two other small fixes I noticed:

1. `numpydoc` should be a dev dependency.
2. The `flo` parameter determining the low frequency cutoff in broadband simulation was hardcoded to 1Hz. This is ok for 100m simulations but should be `0.5Hz` and `0.25Hz` for 200m and 400m simulations respectively. It now uses the value in the broadband config.