### PR TITLE
Relax velocity model version check to accept any string

### DIFF
--- a/workflow/schemas.py
+++ b/workflow/schemas.py
@@ -453,9 +453,7 @@ VELOCITY_MODEL_SCHEMA = Schema(
             "min_vs",
             description="The minimum velocity (km/s) produced in the velocity model.",
         ): And(NUMBER, _is_positive),
-        Literal("version", "Velocity model version"): Or(
-            "2.02", "2.03", "2.06", "2.07", "2.08", "2.09", "2.09_no_basin"
-        ),
+        Literal("version", "Velocity model version"): str,
         Literal("topo_type", "Velocity model topology type"): str,
         Literal("ds_multiplier", "Velocity model ds multiplier"): And(
             NUMBER, _is_positive


### PR DESCRIPTION
The velocity modelling code will throw an error if the version is not compatible, so this change just means we no longer have to open a PR to check this twice