### PR TITLE
fix: dropping eas component in IM calculation

### DIFF
--- a/workflow/scripts/im_calc.py
+++ b/workflow/scripts/im_calc.py
@@ -208,7 +208,7 @@ def calculate_instensity_measures(
             "station": ("station", broadband.station.values),
             "component": (
                 "component",
-                ["000", "090", "ver", "geom", "rotd0", "rotd50", "rotd100"],
+                ["000", "090", "ver", "geom", "rotd0", "rotd50", "rotd100", "eas"],
             ),
             "rrup": ("station", rrup),
             "rjb": ("station", rjb),


### PR DESCRIPTION
We are currently dropping the EAS component of im calculation, this small PR fixes that by adding eas to the initial dataset calculation