### PR TITLE
fix(container): compile EMOD3D with the pre-C23 C dialect

### DIFF
--- a/container/runner.def
+++ b/container/runner.def
@@ -5,9 +5,12 @@ From: earthquakesuc/workflow-bootstrap:latest
     EMOD3D /EMOD3D
 
 %post
+    # Genslip's sources are pre-C23 K&R C, but the base image's GCC defaults to
+    # C23 (where empty parens mean (void), so every fopfile() call is an error)
+    # and errors on implicit declarations. -std=gnu17 -fpermissive are load-bearing.
     cd /EMOD3D && \
       mkdir build && cd build && \
-      cmake -DHF_TIME_WINDOW=off -DUSE_FFTW=on -DCMAKE_C_FLAGS="-march=x86-64 -mtune=generic" .. && \
+      cmake -DHF_TIME_WINDOW=off -DUSE_FFTW=on -DCMAKE_C_FLAGS="-march=x86-64 -mtune=generic -std=gnu17 -fpermissive" .. && \
       make -j $(nproc) genslip_v5.6.2 srf2stoch generic_slip2srf \
                       hb_high_binmod_v6.0.3
 


### PR DESCRIPTION
## Problem

`container/runner.def` cannot build. EMOD3D's Genslip sources are K&R-era C, but the base image's GCC defaults to C23, where an empty parameter list means `(void)`:

```
FILE *fpr, *fopfile();          // C23: fopfile takes NO arguments
...
fpr = fopfile(file,"r");        // error: too many arguments to function 'fopfile'
```

Every `fopfile()` call site becomes a hard error, along with implicit declarations of `setpar`/`mstpar`/`getpar`/`endpar`/`isblank` (errors rather than warnings since GCC 14) and an implicit-`int` `main()` in `srf_join.c`. The build dies in `%post`.

## Fix

Add `-std=gnu17 -fpermissive` to `CMAKE_C_FLAGS`, restoring the dialect the sources were written for. `-std=gnu17` brings back pre-C23 empty-paren semantics; `-fpermissive` downgrades GCC 14's new permerrors to warnings.

## Evidence

- Builds all four targets (`genslip_v5.6.2`, `srf2stoch`, `generic_slip2srf`, `hb_high_binmod_v6.0.3`) with **0 errors**, verified by building an image from this exact def.
- **The flags are codegen-neutral, not just expedient**: `genslip_v5.6.2` and `srf2stoch` come out **bit-identical by SHA256** to the binaries in a previously working `runner.sif`. genslip is compiled from precisely the files that needed the flags (`iofunc.c`, `ruptime.c`, `slip.c`, `srf_subs.c`, `gslip_srf_subs.c`), so this is the strongest form of that evidence — the flags change what the compiler *accepts*, not what it *emits*.
- The workflow test suite passes inside the resulting image (115 passed against the installed package). Note this exercises the Python layer only; no test in the suite executes an EMOD3D binary.

## Notes for review

- **Nothing in CI builds `runner.sif`** — `container.yml` only builds the Docker base image. That is why this def could go unbuildable without anyone noticing, and it also means this branch gets no CI validation.
- **This is a workaround.** The durable fix is upstream in `ucgmsim/EMOD3D`: real prototypes plus the missing `#include <ctype.h>`, after which these flags can come back out. Happy to raise that separately.
- **Unrelated but worth knowing if you rebuild:** current EMOD3D `master` also carries PR #60 (`generic_slip2srf`, including a *"fix units m -> cm"* commit) and HFStoch fixes (NaN waveforms, default alignment). Those two binaries are therefore **not** byte-identical to the old image — by design, upstream. Anyone rebuilding gets a genuine behaviour change in `generic_slip2srf`, which matters for point-source SRF work. Not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)