### PR TITLE
Set std=gnu89 for EMOD3D

### DIFF
--- a/container/runner.def
+++ b/container/runner.def
@@ -7,7 +7,7 @@ From: earthquakesuc/workflow-bootstrap:latest
 %post
     cd /EMOD3D && \
       mkdir build && cd build && \
-      cmake -DHF_TIME_WINDOW=off -DUSE_FFTW=on -DCMAKE_C_FLAGS="-march=x86-64 -mtune=generic" .. && \
+      cmake -DHF_TIME_WINDOW=off -DUSE_FFTW=on -DCMAKE_C_FLAGS="-march=x86-64 -mtune=generic -std=gnu89" .. && \
       make -j $(nproc) genslip_v5.6.2 srf2stoch generic_slip2srf \
                       hb_high_binmod_v6.0.3
 


### PR DESCRIPTION
Code won't build on new GCC versions without setting the standard appropriate for the age of the codebase. 